### PR TITLE
Remove unused OpenAI import

### DIFF
--- a/GPT.py
+++ b/GPT.py
@@ -4,7 +4,6 @@ import datetime
 import threading
 import customtkinter as ctk
 from tkinter import filedialog, messagebox
-import openai
 from openai import OpenAI
 import docx
 import PyPDF2


### PR DESCRIPTION
## Summary
- tidy GPT.py by dropping an unused `openai` import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aab66acec833386422ad0250c9d4d