### PR TITLE
Add dotenv support and basic logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy to .env and add your keys
+OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+venv/
+.env
+conversations/

--- a/GPT.py
+++ b/GPT.py
@@ -2,6 +2,8 @@ import os
 import json
 import datetime
 import threading
+import logging
+
 import customtkinter as ctk
 from tkinter import filedialog, messagebox
 from openai import OpenAI
@@ -12,6 +14,15 @@ import openpyxl
 import base64
 import io
 from typing import Optional, List, Dict
+from dotenv import load_dotenv
+
+# Load environment variables from .env if present
+load_dotenv()
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
 
 # CustomTkinterの設定
 ctk.set_appearance_mode("light")
@@ -27,8 +38,11 @@ class ChatGPTClient:
         api_key = os.getenv("OPENAI_API_KEY")
         if not api_key:
             messagebox.showerror("エラー", "環境変数 OPENAI_API_KEY が設定されていません")
+            logging.error("OPENAI_API_KEY is not set")
             self.window.destroy()
             return
+
+        logging.info("Loaded OpenAI API key from environment")
         
         self.client = OpenAI(api_key=api_key)
         

--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ Install all required Python packages using `requirements.txt`:
 pip install -r requirements.txt
 ```
 
-### 3. Set your OpenAI API key
+### 3. Configure environment variables
 
-The script expects the environment variable `OPENAI_API_KEY` to be set with your OpenAI API key:
+Copy `.env.example` to `.env` and add your OpenAI API key:
 
 ```bash
-export OPENAI_API_KEY=your_key_here  # On Windows use: set OPENAI_API_KEY=your_key_here
+cp .env.example .env
+echo "OPENAI_API_KEY=your_key_here" >> .env
 ```
 
 ### 4. Launch the application

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ python-docx
 PyPDF2
 Pillow
 openpyxl
+python-dotenv
 


### PR DESCRIPTION
## Summary
- load environment variables from `.env` via `python-dotenv`
- configure basic logging
- document env file setup
- add `.env.example` and `.gitignore`
- update requirements

## Testing
- `python -m py_compile GPT.py`


------
https://chatgpt.com/codex/tasks/task_e_685aae0010248333be76107a80a48975