### PR TITLE
Implement minimal ReAct agent with web scraper tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ Then execute the test suite with:
 pytest
 ```
 
+## Simple ReAct Agent
+
+The project includes a minimal implementation of the ReAct agent pattern. To run
+the agent programmatically:
+
+```python
+from src.agent import ReActAgent
+from src.tools import get_web_scraper
+
+def call_llm(prompt: str) -> str:
+    # integrate with your favourite LLM here
+    ...
+
+agent = ReActAgent(call_llm, [get_web_scraper()])
+result = agent.run("東京の天気を教えて")
+```
+
 
 ## License
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,7 @@ PyPDF2
 Pillow
 openpyxl
 python-dotenv
+requests
+beautifulsoup4
+pydantic
 

--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -1,0 +1,1 @@
+from .react_agent import ReActAgent

--- a/src/agent/react_agent.py
+++ b/src/agent/react_agent.py
@@ -1,0 +1,50 @@
+import re
+from typing import Callable, Dict, List
+
+from pydantic import BaseModel
+
+from src.tools.base import Tool, execute_tool
+
+
+class ReActAgent:
+    """Minimal implementation of the ReAct loop."""
+
+    ACTION_RE = re.compile(r"^行動:\s*(\w+):\s*(.*)$", re.MULTILINE)
+    FINAL_RE = re.compile(r"^最終的な答え:\s*(.*)$", re.MULTILINE)
+
+    PROMPT_TEMPLATE = (
+        "あなたは質問に答えるアシスタントです。\n"
+        "利用可能な行動:\n{tools}\n\n"
+        "質問: {input}\n"
+        "{agent_scratchpad}"
+    )
+
+    def __init__(self, llm: Callable[[str], str], tools: List[Tool]):
+        self.llm = llm
+        self.tools = {t.name: t for t in tools}
+
+    def tool_descriptions(self) -> str:
+        descs = []
+        for t in self.tools.values():
+            descs.append(f"- {t.name}: {t.description}")
+        return "\n".join(descs)
+
+    def run(self, question: str, max_turns: int = 5) -> str:
+        scratchpad = ""
+        for _ in range(max_turns):
+            prompt = self.PROMPT_TEMPLATE.format(
+                input=question,
+                tools=self.tool_descriptions(),
+                agent_scratchpad=scratchpad,
+            )
+            output = self.llm(prompt)
+            final_match = self.FINAL_RE.search(output)
+            if final_match:
+                return final_match.group(1)
+            action_match = self.ACTION_RE.search(output)
+            if not action_match:
+                return "エラー: 行動を特定できませんでした"
+            tool_name, tool_input = action_match.groups()
+            observation = execute_tool(tool_name, {"url": tool_input}, self.tools)
+            scratchpad += f"{output}\n観察: {observation}\n"
+        return "エラー: 最大試行回数に達しました"

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,0 +1,4 @@
+from .web_scraper import get_tool as get_web_scraper
+from .base import Tool, execute_tool
+
+__all__ = ["get_web_scraper", "Tool", "execute_tool"]

--- a/src/tools/base.py
+++ b/src/tools/base.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+from typing import Callable, Type
+
+from pydantic import BaseModel
+
+
+@dataclass
+class Tool:
+    """Simple container for tool definitions."""
+
+    name: str
+    description: str
+    func: Callable
+    args_schema: Type[BaseModel]
+
+
+def execute_tool(name: str, args: dict, tools: dict):
+    tool = tools.get(name)
+    if not tool:
+        return f"Unknown tool: {name}"
+    try:
+        parsed = tool.args_schema(**args)
+    except Exception as e:
+        return f"Invalid arguments for {name}: {e}"
+    return tool.func(**parsed.dict())

--- a/src/tools/web_scraper.py
+++ b/src/tools/web_scraper.py
@@ -1,0 +1,39 @@
+from typing import Optional
+import requests
+from bs4 import BeautifulSoup
+from pydantic import BaseModel, Field
+
+from .base import Tool
+
+
+class ScraperInput(BaseModel):
+    url: str = Field(description="WebページのURL")
+    max_chars: Optional[int] = Field(
+        default=1000, description="取得するテキストの最大文字数"
+    )
+
+
+def scrape_website_content(url: str, max_chars: int = 1000) -> str:
+    """Fetch a web page and return cleaned text."""
+    try:
+        response = requests.get(url, headers={"User-Agent": "Mozilla/5.0"}, timeout=10)
+        response.raise_for_status()
+    except Exception as e:
+        return f"Error fetching {url}: {e}"
+
+    soup = BeautifulSoup(response.content, "html.parser")
+    # try to find main content
+    main = soup.find("main") or soup.find("article") or soup.find("body")
+    if not main:
+        return "No content"
+    text = main.get_text(separator=" ", strip=True)
+    return text[:max_chars]
+
+
+def get_tool() -> Tool:
+    return Tool(
+        name="web_scraper",
+        description="指定されたURLから主要テキストを抽出するツール。入力はURL。",
+        func=scrape_website_content,
+        args_schema=ScraperInput,
+    )

--- a/tests/test_react_agent.py
+++ b/tests/test_react_agent.py
@@ -1,0 +1,22 @@
+from src.agent import ReActAgent
+from src.tools.web_scraper import get_tool
+
+
+def test_agent_returns_final_answer(monkeypatch):
+    responses = [
+        "思考: ウェブを検索します\n行動: web_scraper: http://example.com",
+        "最終的な答え: テスト完了",
+    ]
+
+    def fake_llm(prompt):
+        return responses.pop(0)
+
+    agent = ReActAgent(fake_llm, [get_tool()])
+
+    def mock_scrape(url, max_chars=1000):
+        return "dummy"
+
+    monkeypatch.setattr("src.tools.web_scraper.scrape_website_content", mock_scrape)
+
+    answer = agent.run("質問")
+    assert answer == "テスト完了"

--- a/tests/test_web_scraper.py
+++ b/tests/test_web_scraper.py
@@ -1,0 +1,24 @@
+from src.tools.web_scraper import scrape_website_content
+
+
+def test_scrape_local_html(tmp_path, monkeypatch):
+    html = "<html><body><main><p>Hello</p><p>World</p></main></body></html>"
+    file = tmp_path / "index.html"
+    file.write_text(html, encoding="utf-8")
+
+    def mock_get(url, **kwargs):
+        class Resp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            @property
+            def content(self):
+                return html.encode("utf-8")
+
+        return Resp()
+
+    monkeypatch.setattr("requests.get", mock_get)
+    text = scrape_website_content("http://example.com")
+    assert text == "Hello World"


### PR DESCRIPTION
## Summary
- add simple ReActAgent implementation
- implement web_scraper tool with requests and BeautifulSoup
- expose tool and agent in package init files
- update requirements for new dependencies
- document how to run the ReAct agent
- add tests for agent logic and web scraper

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ab77c81f88333876876ce12cc3a2b