### PR TITLE
Implement conversation memory

### DIFF
--- a/src/agent/react_agent.py
+++ b/src/agent/react_agent.py
@@ -1,9 +1,10 @@
 import re
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
 
 from pydantic import BaseModel
 
 from src.tools.base import Tool, execute_tool
+from src.memory import ConversationMemory
 
 
 class ReActAgent:
@@ -19,9 +20,15 @@ class ReActAgent:
         "{agent_scratchpad}"
     )
 
-    def __init__(self, llm: Callable[[str], str], tools: List[Tool]):
+    def __init__(
+        self,
+        llm: Callable[[str], str],
+        tools: List[Tool],
+        memory: Optional[ConversationMemory] = None,
+    ):
         self.llm = llm
         self.tools = {t.name: t for t in tools}
+        self.memory = memory
 
     def tool_descriptions(self) -> str:
         descs = []
@@ -31,20 +38,33 @@ class ReActAgent:
 
     def run(self, question: str, max_turns: int = 5) -> str:
         scratchpad = ""
+        if self.memory is not None:
+            self.memory.add("user", question)
+            history = "\n".join(
+                f"{m['role']}: {m['content']}" for m in self.memory.messages[:-1]
+            )
+        else:
+            history = ""
         for _ in range(max_turns):
             prompt = self.PROMPT_TEMPLATE.format(
                 input=question,
                 tools=self.tool_descriptions(),
-                agent_scratchpad=scratchpad,
+                agent_scratchpad=(history + "\n" + scratchpad if history else scratchpad),
             )
             output = self.llm(prompt)
             final_match = self.FINAL_RE.search(output)
             if final_match:
-                return final_match.group(1)
+                answer = final_match.group(1)
+                if self.memory is not None:
+                    self.memory.add("assistant", answer)
+                return answer
             action_match = self.ACTION_RE.search(output)
             if not action_match:
                 return "エラー: 行動を特定できませんでした"
             tool_name, tool_input = action_match.groups()
             observation = execute_tool(tool_name, {"url": tool_input}, self.tools)
             scratchpad += f"{output}\n観察: {observation}\n"
+            if self.memory is not None:
+                self.memory.add("assistant", output)
+                self.memory.add("system", f"観察: {observation}")
         return "エラー: 最大試行回数に達しました"

--- a/src/memory.py
+++ b/src/memory.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass, field
+from typing import List, Dict
+import json
+
+@dataclass
+class ConversationMemory:
+    """Simple in-memory store for conversation messages."""
+
+    messages: List[Dict[str, str]] = field(default_factory=list)
+
+    def add(self, role: str, content: str) -> None:
+        """Add a message to memory."""
+        self.messages.append({"role": role, "content": content})
+
+    def save(self, path: str) -> None:
+        """Persist messages to a JSON file."""
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump({"messages": self.messages}, f, ensure_ascii=False, indent=2)
+
+    def load(self, path: str) -> None:
+        """Load messages from a JSON file."""
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        self.messages = data.get("messages", [])

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,13 @@
+from src.memory import ConversationMemory
+
+
+def test_memory_save_load(tmp_path):
+    mem = ConversationMemory()
+    mem.add("user", "hello")
+    mem.add("assistant", "hi")
+    file = tmp_path / "conv.json"
+    mem.save(file)
+
+    other = ConversationMemory()
+    other.load(file)
+    assert other.messages == mem.messages


### PR DESCRIPTION
## Summary
- add `ConversationMemory` for storing agent conversations
- extend `ReActAgent` to optionally use memory
- cover new memory functionality with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ab9dc44808333a09d8e90b549d62e