### PR TITLE
Add CLI agent runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ agent = ReActAgent(call_llm, [get_web_scraper()])
 result = agent.run("東京の天気を教えて")
 ```
 
+You can also try the agent from the command line using the built in runner:
+
+```bash
+python -m src.main
+```
+
 
 ## License
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import os
+from dotenv import load_dotenv
+from openai import OpenAI
+
+from src.agent import ReActAgent
+from src.tools.web_scraper import get_tool
+from src.memory import ConversationMemory
+
+
+def create_llm() -> callable:
+    """Create an OpenAI completion callable."""
+    load_dotenv()
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY not set")
+    model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+    client = OpenAI(api_key=api_key)
+
+    def llm(prompt: str) -> str:
+        resp = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return resp.choices[0].message.content
+
+    return llm
+
+
+def main() -> None:
+    llm = create_llm()
+    memory = ConversationMemory()
+    agent = ReActAgent(llm, [get_tool()], memory)
+
+    print("Enter an empty line to quit.")
+    while True:
+        question = input("質問: ").strip()
+        if not question:
+            break
+        answer = agent.run(question)
+        print(f"答え: {answer}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_memory_integration.py
+++ b/tests/test_memory_integration.py
@@ -1,0 +1,25 @@
+from src.agent import ReActAgent
+from src.tools.web_scraper import get_tool
+from src.memory import ConversationMemory
+
+
+def test_agent_updates_memory(monkeypatch):
+    responses = [
+        "思考: 検索\n行動: web_scraper: http://example.com",
+        "最終的な答え: OK",
+    ]
+
+    def fake_llm(prompt: str) -> str:
+        return responses.pop(0)
+
+    memory = ConversationMemory()
+    agent = ReActAgent(fake_llm, [get_tool()], memory)
+
+    monkeypatch.setattr(
+        "src.tools.web_scraper.scrape_website_content", lambda url, max_chars=1000: "dummy"
+    )
+
+    answer = agent.run("質問")
+    assert answer == "OK"
+    assert memory.messages[0]["role"] == "user"
+    assert memory.messages[-1]["content"] == "OK"


### PR DESCRIPTION
## Summary
- add a runnable CLI entry point in `src/main.py`
- test that memory is updated when using `ReActAgent`
- document command-line usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685abc62f35883338731ac0573a657a8