### PR TITLE
Implement verbose logging for ReActAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,13 @@ You can also try the agent from the command line using the built in runner:
 ```bash
 python -m src.main
 ```
+## Verbose Logging
 
+Set `verbose=True` when creating `ReActAgent` to enable debug output using Python's `logging` module.
+
+```python
+agent = ReActAgent(call_llm, [get_web_scraper()], verbose=True)
+```
 
 ## License
 

--- a/tests/test_react_logging.py
+++ b/tests/test_react_logging.py
@@ -1,0 +1,26 @@
+import logging
+from src.agent import ReActAgent
+from src.tools.web_scraper import get_tool
+
+
+def test_verbose_logging(monkeypatch, caplog):
+    responses = [
+        "思考: something\n行動: web_scraper: http://example.com",
+        "最終的な答え: done",
+    ]
+
+    def fake_llm(prompt: str) -> str:
+        return responses.pop(0)
+
+    caplog.set_level(logging.DEBUG)
+    agent = ReActAgent(fake_llm, [get_tool()], verbose=True)
+
+    monkeypatch.setattr(
+        "src.tools.web_scraper.scrape_website_content",
+        lambda url, max_chars=1000: "dummy",
+    )
+
+    agent.run("質問")
+
+    assert "Executing tool web_scraper" in caplog.text
+    assert "Final answer: done" in caplog.text


### PR DESCRIPTION
## Summary
- add optional verbose logging to `ReActAgent`
- document usage of verbose mode in README
- test logging behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685abf1a72488333865089813d86b705