### PR TITLE
Enhance web scraper with caching and robots checks

### DIFF
--- a/tests/test_web_scraper.py
+++ b/tests/test_web_scraper.py
@@ -1,4 +1,6 @@
-from src.tools.web_scraper import scrape_website_content
+from src.tools import web_scraper
+
+scrape_website_content = web_scraper.scrape_website_content
 
 
 def test_scrape_local_html(tmp_path, monkeypatch):
@@ -10,16 +12,28 @@ def test_scrape_local_html(tmp_path, monkeypatch):
         class Resp:
             status_code = 200
 
+            def __init__(self, content):
+                self._content = content
+
             def raise_for_status(self):
                 pass
 
             @property
             def content(self):
-                return html.encode("utf-8")
+                return self._content.encode("utf-8")
 
-        return Resp()
+            @property
+            def text(self):
+                return self._content
 
-    monkeypatch.setattr("requests.get", mock_get)
+        if url.endswith("robots.txt"):
+            return Resp("User-agent: *\nAllow: /")
+        return Resp(html)
+
+    import requests
+    monkeypatch.setattr(requests, "get", mock_get)
+    web_scraper._CACHE.clear()
+    web_scraper._ROBOTS.clear()
     text = scrape_website_content("http://example.com")
     assert text == "Hello World"
 
@@ -36,15 +50,102 @@ def test_scrape_removes_noise(tmp_path, monkeypatch):
         class Resp:
             status_code = 200
 
+            def __init__(self, content):
+                self._content = content
+
             def raise_for_status(self):
                 pass
 
             @property
             def content(self):
-                return html.encode("utf-8")
+                return self._content.encode("utf-8")
 
-        return Resp()
+            @property
+            def text(self):
+                return self._content
 
-    monkeypatch.setattr("requests.get", mock_get)
+        if url.endswith("robots.txt"):
+            return Resp("User-agent: *\nAllow: /")
+        return Resp(html)
+
+    import requests
+    monkeypatch.setattr(requests, "get", mock_get)
+    web_scraper._CACHE.clear()
+    web_scraper._ROBOTS.clear()
     text = scrape_website_content("http://example.com")
     assert text == "Hi"
+
+
+def test_respects_robots(monkeypatch):
+    call_count = {"n": 0}
+
+    def mock_get(url, **kwargs):
+        call_count["n"] += 1
+
+        class Resp:
+            status_code = 200
+
+            def __init__(self, content):
+                self._content = content
+
+            def raise_for_status(self):
+                pass
+
+            @property
+            def content(self):
+                return self._content.encode("utf-8")
+
+            @property
+            def text(self):
+                return self._content
+
+        if url.endswith("robots.txt"):
+            return Resp("User-agent: *\nDisallow: /")
+        return Resp("<html><body><main>Hi</main></body></html>")
+
+    web_scraper._CACHE.clear()
+    web_scraper._ROBOTS.clear()
+    import requests
+    monkeypatch.setattr(requests, "get", mock_get)
+    text = scrape_website_content("http://example.com/page")
+    assert "Disallowed" in text
+    # Should only fetch robots since page is disallowed
+    assert call_count["n"] == 1
+
+
+def test_caching(monkeypatch):
+    call_count = {"n": 0}
+
+    def mock_get(url, **kwargs):
+        call_count["n"] += 1
+
+        class Resp:
+            status_code = 200
+
+            def __init__(self, content):
+                self._content = content
+
+            def raise_for_status(self):
+                pass
+
+            @property
+            def content(self):
+                return self._content.encode("utf-8")
+
+            @property
+            def text(self):
+                return self._content
+
+        if url.endswith("robots.txt"):
+            return Resp("User-agent: *\nAllow: /")
+        return Resp("<html><body><main>Hi</main></body></html>")
+
+    web_scraper._CACHE.clear()
+    web_scraper._ROBOTS.clear()
+    import requests
+    monkeypatch.setattr(requests, "get", mock_get)
+    a = scrape_website_content("http://example.com")
+    b = scrape_website_content("http://example.com")
+    assert a == b == "Hi"
+    # Should have fetched robots once and page once
+    assert call_count["n"] == 2


### PR DESCRIPTION
## Summary
- respect robots.txt and add caching for the web scraper tool
- update tests for new behaviour and add coverage for caching and robots rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac08d85bc8333aebf60835483cc4a