### PR TITLE
Add streaming iterator for ReActAgent

### DIFF
--- a/tests/test_react_agent.py
+++ b/tests/test_react_agent.py
@@ -20,3 +20,24 @@ def test_agent_returns_final_answer(monkeypatch):
 
     answer = agent.run("質問")
     assert answer == "テスト完了"
+
+
+def test_run_iter_yields_steps(monkeypatch):
+    responses = [
+        "思考: 検索します\n行動: web_scraper: http://example.com",
+        "最終的な答え: ok",
+    ]
+
+    def fake_llm(prompt: str) -> str:
+        return responses.pop(0)
+
+    monkeypatch.setattr(
+        "src.tools.web_scraper.scrape_website_content", lambda url, max_chars=1000: "dummy"
+    )
+    agent = ReActAgent(fake_llm, [get_tool()])
+
+    steps = list(agent.run_iter("質問"))
+    assert steps[0].startswith("思考")
+    assert steps[1] == "観察: dummy"
+    assert steps[2].startswith("最終的な答え")
+    assert steps[3] == "ok"


### PR DESCRIPTION
## Summary
- allow ReActAgent to yield intermediate steps with `run_iter`
- simplify `run` by using the new generator
- cover generator behaviour in tests

## Testing
- `pip install -q -r requirements-dev.txt`
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac36ce9ac8333ac8c2c9096610769