### PR TITLE
Add simple ReAct agent desktop UI

### DIFF
--- a/src/ui/agent_app.py
+++ b/src/ui/agent_app.py
@@ -1,0 +1,90 @@
+import queue
+import threading
+import tkinter
+import customtkinter as ctk
+from typing import Callable
+
+from src.agent import ReActAgent
+from src.tools import get_web_scraper
+from src.main import create_llm
+
+
+def agent_worker(question: str, agent: ReActAgent, result_queue: queue.Queue) -> None:
+    """Run the agent and push steps to the queue."""
+    try:
+        for step in agent.run_iter(question):
+            result_queue.put(step)
+    except Exception as e:
+        result_queue.put(f"エラー: {e}")
+
+
+class AgentApp(ctk.CTk):
+    """Simple interface for interacting with ReActAgent."""
+
+    def __init__(self, llm: Callable[[str], str] | None = None) -> None:
+        super().__init__()
+
+        self.title("ReAct Agent")
+        self.geometry("800x600")
+
+        self.grid_columnconfigure(1, weight=1)
+        self.grid_rowconfigure(0, weight=1)
+
+        self.left_frame = ctk.CTkFrame(self, width=200, corner_radius=0)
+        self.left_frame.grid(row=0, column=0, sticky="nsew")
+        self.left_frame.grid_rowconfigure(3, weight=1)
+
+        self.entry = ctk.CTkEntry(self.left_frame, placeholder_text="質問を入力してください")
+        self.entry.grid(row=0, column=0, padx=20, pady=(20, 10))
+
+        self.run_button = ctk.CTkButton(self.left_frame, text="実行", command=self.start_agent)
+        self.run_button.grid(row=1, column=0, padx=20, pady=10)
+
+        self.right_frame = ctk.CTkFrame(self)
+        self.right_frame.grid(row=0, column=1, sticky="nsew", padx=20, pady=20)
+        self.right_frame.grid_rowconfigure(0, weight=1)
+        self.right_frame.grid_columnconfigure(0, weight=1)
+
+        self.textbox = ctk.CTkTextbox(self.right_frame, width=400)
+        self.textbox.grid(row=0, column=0, sticky="nsew")
+        self.textbox.configure(state="disabled")
+
+        self.result_queue: queue.Queue[str] = queue.Queue()
+
+        if llm is None:
+            llm = create_llm()
+        self.agent = ReActAgent(llm, [get_web_scraper()])
+
+    def start_agent(self) -> None:
+        question = self.entry.get().strip()
+        if not question:
+            return
+
+        self.textbox.configure(state="normal")
+        self.textbox.delete("1.0", tkinter.END)
+        self.textbox.insert("1.0", f"質問: {question}\n\n")
+        self.textbox.configure(state="disabled")
+
+        self.run_button.configure(state="disabled")
+        thread = threading.Thread(target=agent_worker, args=(question, self.agent, self.result_queue))
+        thread.start()
+        self.after(100, self.check_queue)
+
+    def check_queue(self) -> None:
+        try:
+            message = self.result_queue.get_nowait()
+            self.textbox.configure(state="normal")
+            self.textbox.insert(tkinter.END, message + "\n")
+            self.textbox.configure(state="disabled")
+
+            if message.startswith("最終的な答え:") or message.startswith("エラー:"):
+                self.run_button.configure(state="normal")
+            else:
+                self.after(100, self.check_queue)
+        except queue.Empty:
+            self.after(100, self.check_queue)
+
+
+if __name__ == "__main__":
+    app = AgentApp()
+    app.mainloop()

--- a/tests/test_agent_app.py
+++ b/tests/test_agent_app.py
@@ -1,0 +1,37 @@
+import queue
+
+from pydantic import BaseModel, Field
+
+from src.agent import ReActAgent
+from src.tools.base import Tool
+from src.ui.agent_app import agent_worker
+
+
+class DummyInput(BaseModel):
+    url: str = Field(description="dummy")
+
+def test_agent_worker_puts_steps():
+    responses = [
+        "思考: test\n行動: dummy_tool: arg",
+        "最終的な答え: done",
+    ]
+
+    def fake_llm(prompt: str) -> str:
+        return responses.pop(0)
+
+    def dummy_func(url: str):
+        return "obs"
+
+    tool = Tool(name="dummy_tool", description="d", func=dummy_func, args_schema=DummyInput)
+    agent = ReActAgent(fake_llm, [tool])
+
+    q: queue.Queue[str] = queue.Queue()
+    agent_worker("q", agent, q)
+    outputs = []
+    while not q.empty():
+        outputs.append(q.get())
+
+    assert outputs[0].startswith("思考")
+    assert outputs[1] == "観察: obs"
+    # The agent yields the LLM output and then the final answer separately
+    assert outputs[-2].startswith("最終的な答え:")


### PR DESCRIPTION
## Summary
- add `AgentApp` GUI using CustomTkinter
- run agent loop on a background thread with `agent_worker`
- test worker logic for queue updates

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac4f42f4c833392001070e6ca3f78