### PR TITLE
Improve usage logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 # Copy to .env and add your keys
 OPENAI_API_KEY=
+# Optional token price per token for usage cost logging
+# OPENAI_TOKEN_PRICE=

--- a/README.md
+++ b/README.md
@@ -84,6 +84,19 @@ Set `verbose=True` when creating `ReActAgent` to enable debug output using Pytho
 agent = ReActAgent(call_llm, [get_web_scraper()], verbose=True)
 ```
 
+## Token Usage Tracking
+
+The `create_llm` helper can log the number of tokens consumed and estimate the
+cost of each OpenAI API call. Set `OPENAI_TOKEN_PRICE` in your environment to the
+price per token (e.g. `0.000002`) and pass `log_usage=True` when creating the
+LLM:
+
+```python
+llm = create_llm(log_usage=True)
+```
+
+Log records will include the token count and calculated cost.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import logging
 from dotenv import load_dotenv
 from openai import OpenAI
 
@@ -8,14 +9,24 @@ from src.agent import ReActAgent
 from src.tools.web_scraper import get_tool
 from src.memory import ConversationMemory
 
+logger = logging.getLogger(__name__)
 
-def create_llm() -> callable:
-    """Create an OpenAI completion callable."""
+
+def create_llm(*, log_usage: bool = False) -> callable:
+    """Create an OpenAI completion callable.
+
+    Parameters
+    ----------
+    log_usage: bool
+        If True, token usage and estimated cost from the OpenAI API response
+        will be logged.
+    """
     load_dotenv()
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY not set")
     model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+    token_price = float(os.getenv("OPENAI_TOKEN_PRICE", "0"))
     client = OpenAI(api_key=api_key)
 
     def llm(prompt: str) -> str:
@@ -23,13 +34,21 @@ def create_llm() -> callable:
             model=model,
             messages=[{"role": "user", "content": prompt}],
         )
+        if log_usage and getattr(resp, "usage", None):
+            try:
+                total = resp.usage.total_tokens
+            except Exception as exc:
+                logger.warning("Failed to read token usage: %s", exc)
+            else:
+                cost = total * token_price
+                logger.info("Tokens used: %s | Cost: $%.4f", total, cost)
         return resp.choices[0].message.content
 
     return llm
 
 
 def main() -> None:
-    llm = create_llm()
+    llm = create_llm(log_usage=True)
     memory = ConversationMemory()
     agent = ReActAgent(llm, [get_tool()], memory)
 

--- a/src/ui/agent_app.py
+++ b/src/ui/agent_app.py
@@ -19,9 +19,9 @@ def agent_worker(question: str, agent: ReActAgent, result_queue: queue.Queue) ->
 
 
 class AgentApp(ctk.CTk):
-    """Simple interface for interacting with ReActAgent."""
+    """Simple interface for interacting with :class:`ReActAgent`."""
 
-    def __init__(self, llm: Callable[[str], str] | None = None) -> None:
+    def __init__(self, llm: Callable[[str], str] | None = None, *, log_usage: bool = False) -> None:
         super().__init__()
 
         self.title("ReAct Agent")
@@ -52,7 +52,7 @@ class AgentApp(ctk.CTk):
         self.result_queue: queue.Queue[str] = queue.Queue()
 
         if llm is None:
-            llm = create_llm()
+            llm = create_llm(log_usage=log_usage)
         self.agent = ReActAgent(llm, [get_web_scraper()])
 
     def start_agent(self) -> None:
@@ -86,5 +86,5 @@ class AgentApp(ctk.CTk):
 
 
 if __name__ == "__main__":
-    app = AgentApp()
+    app = AgentApp(log_usage=True)
     app.mainloop()

--- a/tests/test_usage_logging.py
+++ b/tests/test_usage_logging.py
@@ -1,0 +1,28 @@
+import logging
+from types import SimpleNamespace
+
+from src import main as src_main
+
+class DummyResp:
+    def __init__(self):
+        msg = SimpleNamespace(content="ok")
+        self.choices = [SimpleNamespace(message=msg)]
+        self.usage = SimpleNamespace(total_tokens=42)
+
+class DummyClient:
+    def __init__(self):
+        self.chat = self
+        self.completions = self
+    def create(self, model, messages):
+        return DummyResp()
+
+
+def test_create_llm_logs_usage(monkeypatch, caplog):
+    caplog.set_level(logging.INFO)
+    monkeypatch.setattr(src_main, "OpenAI", lambda api_key: DummyClient())
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setenv("OPENAI_TOKEN_PRICE", "0.001")
+    llm = src_main.create_llm(log_usage=True)
+    llm("hi")
+    assert "Tokens used: 42" in caplog.text
+    assert "Cost: $0.0420" in caplog.text


### PR DESCRIPTION
## Summary
- refine token logging logic in `create_llm`
- remove unused import in test
- log usage cost with optional OPENAI_TOKEN_PRICE env var
- expose log_usage parameter in desktop UI and README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b20e610c08333ba833e0f90085146