### PR TITLE
Improve memory integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests
 beautifulsoup4
 pydantic
 
+scikit-learn

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,17 @@
+"""Public package interface."""
+
+from .memory import ConversationMemory, BaseMemory
+from .vector_memory import VectorMemory
+from .agent import ReActAgent
+from .tools import get_web_scraper, get_sqlite_tool, Tool, execute_tool
+
+__all__ = [
+    "ConversationMemory",
+    "VectorMemory",
+    "BaseMemory",
+    "ReActAgent",
+    "get_web_scraper",
+    "get_sqlite_tool",
+    "Tool",
+    "execute_tool",
+]

--- a/src/memory.py
+++ b/src/memory.py
@@ -1,6 +1,24 @@
 from dataclasses import dataclass, field
-from typing import List, Dict
+from typing import List, Dict, Protocol
 import json
+
+
+class BaseMemory(Protocol):
+    """Protocol for memory implementations."""
+
+    messages: List[Dict[str, str]]
+
+    def add(self, role: str, content: str) -> None:
+        ...
+
+    def save(self, path: str) -> None:
+        ...
+
+    def load(self, path: str) -> None:
+        ...
+
+    def search(self, query: str, top_k: int = 3) -> List[str]:
+        ...
 
 @dataclass
 class ConversationMemory:
@@ -22,3 +40,8 @@ class ConversationMemory:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
         self.messages = data.get("messages", [])
+
+    def search(self, query: str, top_k: int = 3) -> List[str]:
+        """Return messages containing the query text."""
+        results = [m["content"] for m in self.messages if query in m["content"]]
+        return results[:top_k]

--- a/src/vector_memory.py
+++ b/src/vector_memory.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass, field
+from typing import List, Dict
+import json
+
+from .memory import BaseMemory
+
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+@dataclass
+class VectorMemory(BaseMemory):
+    """Conversation memory backed by a simple vector store using TF-IDF."""
+
+    messages: List[Dict[str, str]] = field(default_factory=list)
+
+    def add(self, role: str, content: str) -> None:
+        """Add a message to memory."""
+        self.messages.append({"role": role, "content": content})
+
+    def search(self, query: str, top_k: int = 3) -> List[str]:
+        """Return the contents of the messages most similar to the query."""
+        corpus = [m["content"] for m in self.messages]
+        if not corpus:
+            return []
+        vectorizer = TfidfVectorizer()
+        vectors = vectorizer.fit_transform(corpus + [query])
+        sims = cosine_similarity(vectors[-1], vectors[:-1]).flatten()
+        indices = sims.argsort()[::-1][:top_k]
+        return [corpus[i] for i in indices]
+
+    def save(self, path: str) -> None:
+        """Persist messages to a JSON file."""
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump({"messages": self.messages}, f, ensure_ascii=False, indent=2)
+
+    def load(self, path: str) -> None:
+        """Load messages from a JSON file."""
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        self.messages = data.get("messages", [])

--- a/tests/test_sqlite_tool_agent.py
+++ b/tests/test_sqlite_tool_agent.py
@@ -1,0 +1,25 @@
+from src.agent import ReActAgent
+from src.tools.sqlite_tool import get_tool
+
+
+def test_agent_uses_sqlite_query_tool(monkeypatch, tmp_path):
+    db_path = tmp_path / "test.db"
+    import sqlite3
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT)")
+    conn.execute("INSERT INTO items(name) VALUES('apple')")
+    conn.commit()
+    conn.close()
+
+    outputs = [
+        "思考: データベースを調べます\n行動: sqlite_query: {\"path\": \"%s\", \"query\": \"SELECT name FROM items\"}" % db_path,
+        "最終的な答え: done",
+    ]
+
+    def fake_llm(prompt: str) -> str:
+        return outputs.pop(0)
+
+    agent = ReActAgent(fake_llm, [get_tool()])
+
+    answer = agent.run("?")
+    assert answer == "done"

--- a/tests/test_vector_memory.py
+++ b/tests/test_vector_memory.py
@@ -1,0 +1,21 @@
+from src.vector_memory import VectorMemory
+
+
+def test_search_returns_similar_messages():
+    mem = VectorMemory()
+    mem.add("user", "今日は良い天気です")
+    mem.add("assistant", "はい、晴れています")
+    mem.add("user", "昨日は雨でした")
+
+    results = mem.search("天気", top_k=2)
+    assert any("天気" in r or "晴れ" in r for r in results)
+
+
+def test_save_and_load(tmp_path):
+    mem = VectorMemory()
+    mem.add("user", "hello")
+    file = tmp_path / "vec.json"
+    mem.save(file)
+    other = VectorMemory()
+    other.load(file)
+    assert other.messages == mem.messages

--- a/tests/test_vector_memory_agent.py
+++ b/tests/test_vector_memory_agent.py
@@ -1,0 +1,19 @@
+from src.agent import ReActAgent
+from src.vector_memory import VectorMemory
+
+
+def test_agent_uses_vector_memory_search():
+    mem = VectorMemory()
+    mem.add("user", "Pythonについて話そう")
+    mem.add("assistant", "はい、Pythonは人気があります")
+
+    captured = {}
+
+    def fake_llm(prompt: str) -> str:
+        captured['prompt'] = prompt
+        return "最終的な答え: ok"
+
+    agent = ReActAgent(fake_llm, [], mem)
+    answer = agent.run("Pythonの利用例は？")
+    assert answer == "ok"
+    assert "Pythonについて話そう" in captured['prompt']


### PR DESCRIPTION
## Summary
- define `BaseMemory` protocol and add a basic search to `ConversationMemory`
- inherit `VectorMemory` from this protocol
- expose all main classes in the package `__init__`
- use memory search results when prompting `ReActAgent`
- parse JSON tool arguments in `ReActAgent`
- test agent prompt with `VectorMemory`
- test SQLite integration via `ReActAgent`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3dbfd9048333b15bd9625f4e9a6d