### PR TITLE
Integrate SQLite tool with agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,27 +61,29 @@ the agent programmatically:
 
 ```python
 from src.agent import ReActAgent
-from src.tools import get_web_scraper
+from src.tools import get_web_scraper, get_sqlite_tool
 
 def call_llm(prompt: str) -> str:
     # integrate with your favourite LLM here
     ...
 
-agent = ReActAgent(call_llm, [get_web_scraper()])
+agent = ReActAgent(call_llm, [get_web_scraper(), get_sqlite_tool()])
 result = agent.run("東京の天気を教えて")
 ```
+The agent includes a web scraping tool and a SQLite query tool.
 
 You can also try the agent from the command line using the built in runner:
 
 ```bash
 python -m src.main
 ```
+The command line runner loads both tools by default.
 ## Verbose Logging
 
 Set `verbose=True` when creating `ReActAgent` to enable debug output using Python's `logging` module.
 
 ```python
-agent = ReActAgent(call_llm, [get_web_scraper()], verbose=True)
+agent = ReActAgent(call_llm, [get_web_scraper(), get_sqlite_tool()], verbose=True)
 ```
 
 ## Token Usage Tracking

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 from openai import OpenAI
 
 from src.agent import ReActAgent
-from src.tools.web_scraper import get_tool
+from src.tools import get_web_scraper, get_sqlite_tool
 from src.memory import ConversationMemory
 
 logger = logging.getLogger(__name__)
@@ -50,7 +50,8 @@ def create_llm(*, log_usage: bool = False) -> callable:
 def main() -> None:
     llm = create_llm(log_usage=True)
     memory = ConversationMemory()
-    agent = ReActAgent(llm, [get_tool()], memory)
+    tools = [get_web_scraper(), get_sqlite_tool()]
+    agent = ReActAgent(llm, tools, memory)
 
     print("Enter an empty line to quit.")
     while True:

--- a/src/ui/agent_app.py
+++ b/src/ui/agent_app.py
@@ -5,7 +5,7 @@ import customtkinter as ctk
 from typing import Callable
 
 from src.agent import ReActAgent
-from src.tools import get_web_scraper
+from src.tools import get_web_scraper, get_sqlite_tool
 from src.main import create_llm
 
 
@@ -53,7 +53,8 @@ class AgentApp(ctk.CTk):
 
         if llm is None:
             llm = create_llm(log_usage=log_usage)
-        self.agent = ReActAgent(llm, [get_web_scraper()])
+        tools = [get_web_scraper(), get_sqlite_tool()]
+        self.agent = ReActAgent(llm, tools)
 
     def start_agent(self) -> None:
         question = self.entry.get().strip()


### PR DESCRIPTION
## Summary
- load the SQLite query tool alongside the web scraper
- expose both tools in the CLI runner and GUI application
- document usage of the SQLite tool in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b8e7cae80833386360e07034c449b