### PR TITLE
Add CLI memory selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,12 @@ You can also try the agent from the command line using the built in runner:
 ```bash
 python -m src.main
 ```
-The command line runner loads both tools by default.
+The command line runner loads both tools by default. You can pass `--memory vector`
+to enable the `VectorMemory` store instead of the default conversation memory:
+
+```bash
+python -m src.main --memory vector
+```
 ## Verbose Logging
 
 Set `verbose=True` when creating `ReActAgent` to enable debug output using Python's `logging` module.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,29 @@
+import types
+from src import main as src_main
+
+
+def test_parse_args():
+    args = src_main.parse_args(['--memory', 'vector'])
+    assert args.memory == 'vector'
+
+
+def test_main_uses_vector_memory(monkeypatch):
+    created = {}
+
+    class DummyAgent:
+        def __init__(self, llm, tools, memory):
+            created['memory'] = memory
+        def run(self, q):
+            return 'ok'
+
+    monkeypatch.setattr(src_main, 'ReActAgent', DummyAgent)
+    monkeypatch.setattr(src_main, 'create_llm', lambda log_usage=True: lambda p: 'x')
+    monkeypatch.setattr(src_main, 'setup_logging', lambda: None)
+    monkeypatch.setattr(src_main, 'get_web_scraper', lambda: None)
+    monkeypatch.setattr(src_main, 'get_sqlite_tool', lambda: None)
+    monkeypatch.setattr('builtins.input', lambda prompt='': '')
+    monkeypatch.setattr('builtins.print', lambda *a, **k: None)
+
+    src_main.main(['--memory', 'vector'])
+    assert isinstance(created['memory'], src_main.VectorMemory)
+


### PR DESCRIPTION
## Summary
- add argparse handling to `src.main`
- allow choosing between ConversationMemory and VectorMemory
- document the new option in README
- test CLI argument and memory selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b977e80d08333a627020ece3573f3