### PR TITLE
Implement memory persistence option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ to enable the `VectorMemory` store instead of the default conversation memory:
 ```bash
 python -m src.main --memory vector
 ```
+You can persist the conversation across runs by specifying `--memory-file` with a
+path to a JSON file. The memory will be loaded at startup and saved when the
+program exits:
+
+```bash
+python -m src.main --memory-file chat.json
+```
 ## Verbose Logging
 
 Set `verbose=True` when creating `ReActAgent` to enable debug output using Python's `logging` module.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,10 +1,15 @@
 import types
+import json
 from src import main as src_main
 
 
 def test_parse_args():
     args = src_main.parse_args(['--memory', 'vector'])
     assert args.memory == 'vector'
+
+def test_parse_args_memory_file():
+    args = src_main.parse_args(['--memory-file', 'mem.json'])
+    assert args.memory_file == 'mem.json'
 
 
 def test_main_uses_vector_memory(monkeypatch):
@@ -26,4 +31,42 @@ def test_main_uses_vector_memory(monkeypatch):
 
     src_main.main(['--memory', 'vector'])
     assert isinstance(created['memory'], src_main.VectorMemory)
+
+
+def test_main_loads_and_saves_memory(tmp_path, monkeypatch):
+    mem_file = tmp_path / 'mem.json'
+    mem_file.write_text('{"messages": []}', encoding='utf-8')
+
+    loaded = {'val': False}
+    saved = {'val': False}
+
+    class DummyMemory(src_main.ConversationMemory):
+        def load(self, path: str) -> None:
+            loaded['val'] = True
+            super().load(path)
+
+        def save(self, path: str) -> None:
+            saved['val'] = True
+            super().save(path)
+
+    class DummyAgent:
+        def __init__(self, llm, tools, memory):
+            self.memory = memory
+        def run(self, q):
+            return 'ok'
+
+    monkeypatch.setattr(src_main, 'ReActAgent', DummyAgent)
+    monkeypatch.setattr(src_main, 'create_llm', lambda log_usage=True: lambda p: 'x')
+    monkeypatch.setattr(src_main, 'setup_logging', lambda: None)
+    monkeypatch.setattr(src_main, 'get_web_scraper', lambda: None)
+    monkeypatch.setattr(src_main, 'get_sqlite_tool', lambda: None)
+    monkeypatch.setattr(src_main, 'ConversationMemory', DummyMemory)
+    monkeypatch.setattr(src_main, 'VectorMemory', DummyMemory)
+    monkeypatch.setattr('builtins.input', lambda prompt='': '')
+    monkeypatch.setattr('builtins.print', lambda *a, **k: None)
+
+    src_main.main(['--memory-file', str(mem_file)])
+
+    assert loaded['val']
+    assert saved['val']
 


### PR DESCRIPTION
## Summary
- support `--memory-file` in CLI to load and save conversation history
- document memory persistence in README
- test CLI argument parsing and persistence logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ba1fc35408333b36b2f70dff72e04