### PR TITLE
Implement simple ToT agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,27 @@ program exits:
 ```bash
 python -m src.main --memory-file chat.json
 ```
+
+## Experimental ToT Agent
+
+The repository also ships with a tiny Tree-of-Thoughts agent. It explores
+multiple branches and chooses the one with the highest evaluation score.
+
+```python
+from src.agent import ToTAgent
+
+def llm(prompt: str) -> str:
+    ...
+
+def evaluate(history: str) -> float:
+    ...
+
+agent = ToTAgent(llm, evaluate)
+answer = agent.run("質問")
+```
+
+This implementation is intentionally simple but shows how an LLM can be used in
+a branch-and-bound style search loop.
 ## Verbose Logging
 
 Set `verbose=True` when creating `ReActAgent` to enable debug output using Python's `logging` module.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,7 @@
 
 from .memory import ConversationMemory, BaseMemory
 from .vector_memory import VectorMemory
-from .agent import ReActAgent
+from .agent import ReActAgent, ToTAgent
 from .tools import get_web_scraper, get_sqlite_tool, Tool, execute_tool
 from .logging_utils import setup_logging
 
@@ -11,6 +11,7 @@ __all__ = [
     "VectorMemory",
     "BaseMemory",
     "ReActAgent",
+    "ToTAgent",
     "get_web_scraper",
     "get_sqlite_tool",
     "Tool",

--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -1,1 +1,4 @@
 from .react_agent import ReActAgent
+from .tot_agent import ToTAgent
+
+__all__ = ["ReActAgent", "ToTAgent"]

--- a/src/agent/tot_agent.py
+++ b/src/agent/tot_agent.py
@@ -1,0 +1,76 @@
+import re
+from typing import Callable, List, Tuple
+
+
+class ToTAgent:
+    """Minimal Tree-of-Thoughts style agent.
+
+    The agent explores a search tree of candidate thought sequences.
+    At each depth it expands the best nodes according to an evaluation
+    function and finally asks the LLM to produce an answer based on the
+    highest scoring path.
+    """
+
+    THOUGHT_RE = re.compile(r"^-\s*(.+)", re.MULTILINE)
+    FINAL_RE = re.compile(r"^最終的な答え:\s*(.*)$", re.MULTILINE)
+
+    def __init__(
+        self,
+        llm: Callable[[str], str],
+        evaluate: Callable[[str], float],
+        *,
+        max_depth: int = 2,
+        breadth: int = 2,
+    ) -> None:
+        """Create a new agent.
+
+        Parameters
+        ----------
+        llm:
+            Callable that takes a prompt and returns a completion.
+        evaluate:
+            Function scoring a history string, higher is better.
+        max_depth:
+            How many rounds of expansion to perform.
+        breadth:
+            How many candidates to keep at each depth.
+        """
+        self.llm = llm
+        self.evaluate = evaluate
+        self.max_depth = max_depth
+        self.breadth = breadth
+
+    def _propose(self, question: str, history: str) -> List[str]:
+        """Ask the LLM for the next thought candidates."""
+        prompt = (
+            f"質問: {question}\n"
+            f"これまでの思考:\n{history}\n"
+            f"{self.breadth}個の次の思考候補を箇条書きで提案してください。"
+        )
+        output = self.llm(prompt)
+        return [m.group(1).strip() for m in self.THOUGHT_RE.finditer(output)]
+
+    def _final(self, question: str, history: str) -> str:
+        """Request the final answer from the LLM."""
+        prompt = f"質問: {question}\n思考過程:\n{history}\n最終的な答え:"
+        resp = self.llm(prompt)
+        match = self.FINAL_RE.search(resp)
+        return match.group(1).strip() if match else resp.strip()
+
+    def run(self, question: str) -> str:
+        """Execute the search loop and return the final answer."""
+        nodes: List[Tuple[str, float]] = [("", 0.0)]
+        for _ in range(self.max_depth):
+            candidates: List[Tuple[str, float]] = []
+            for hist, _score in nodes:
+                thoughts = self._propose(question, hist)
+                for t in thoughts:
+                    new_hist = (hist + "\n" + t) if hist else t
+                    score = self.evaluate(new_hist)
+                    candidates.append((new_hist, score))
+            if not candidates:
+                break
+            candidates.sort(key=lambda x: x[1], reverse=True)
+            nodes = candidates[: self.breadth]
+        best_history = nodes[0][0]
+        return self._final(question, best_history)

--- a/tests/test_tot_agent.py
+++ b/tests/test_tot_agent.py
@@ -1,0 +1,20 @@
+from src.agent import ToTAgent
+
+
+def test_tot_agent_selects_best_path():
+    prompts = []
+
+    def fake_llm(prompt: str) -> str:
+        prompts.append(prompt)
+        if "箇条書き" in prompt:
+            return "- A\n- B"
+        return "最終的な答え: done"
+
+    def evaluate(history: str) -> float:
+        return 1.0 if "B" in history else 0.0
+
+    agent = ToTAgent(fake_llm, evaluate, max_depth=1, breadth=2)
+    answer = agent.run("test")
+
+    assert answer == "done"
+    assert "B" in prompts[-1]


### PR DESCRIPTION
## Summary
- implement `ToTAgent` with a minimal tree-of-thoughts search loop
- expose the new agent in package initializers
- document ToT agent usage in README
- expand docstrings for clarity

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685baee6b9dc8333b58516aa799291d4