### PR TITLE
Add ToT agent CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ to enable the `VectorMemory` store instead of the default conversation memory:
 ```bash
 python -m src.main --memory vector
 ```
+To run the experimental Tree-of-Thoughts agent instead of ReAct:
+
+```bash
+python -m src.main --agent tot
+```
 You can persist the conversation across runs by specifying `--memory-file` with a
 path to a JSON file. The memory will be loaded at startup and saved when the
 program exits:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -70,3 +70,24 @@ def test_main_loads_and_saves_memory(tmp_path, monkeypatch):
     assert loaded['val']
     assert saved['val']
 
+
+def test_main_uses_tot_agent(monkeypatch):
+    created = {}
+
+    class DummyTot:
+        def __init__(self, llm, evaluate):
+            created['called'] = True
+        def run(self, q):
+            return 'ok'
+
+    monkeypatch.setattr(src_main, 'ToTAgent', DummyTot)
+    monkeypatch.setattr(src_main, 'create_llm', lambda log_usage=True: lambda p: 'x')
+    monkeypatch.setattr(src_main, 'create_evaluator', lambda llm: lambda h: 1.0)
+    monkeypatch.setattr(src_main, 'setup_logging', lambda: None)
+    monkeypatch.setattr('builtins.input', lambda prompt='': '')
+    monkeypatch.setattr('builtins.print', lambda *a, **k: None)
+
+    src_main.main(['--agent', 'tot'])
+
+    assert created.get('called', False)
+


### PR DESCRIPTION
## Summary
- support choosing between ReAct and ToT agents in the CLI
- add helper `create_evaluator` for ToT evaluation
- document the `--agent tot` option in the README
- avoid creating memory/tools when running the ToT agent

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc41671b88333895ecc398ec070ac