### PR TITLE
Implement scraper env settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ llm = create_llm(log_usage=True)
 
 Log records will include the token count and calculated cost.
 
+## Web Scraper Settings
+
+The built-in web scraping tool caches pages and waits between requests. You can
+adjust these values with environment variables:
+
+- `WEB_SCRAPER_CACHE_TTL` – cache duration in seconds (default `3600`)
+- `WEB_SCRAPER_DELAY` – delay between HTTP requests in seconds (default `1.0`)
+
 ## Configuring Logging
 
 Use `setup_logging` to send logs to both the console and optionally a file.

--- a/src/agent/react_agent.py
+++ b/src/agent/react_agent.py
@@ -3,10 +3,8 @@ import logging
 import json
 from typing import Callable, Dict, List, Optional, Iterator
 
-from pydantic import BaseModel
-
 from src.tools.base import Tool, execute_tool
-from src.memory import BaseMemory, ConversationMemory
+from src.memory import BaseMemory
 
 
 logger = logging.getLogger(__name__)

--- a/src/tools/web_scraper.py
+++ b/src/tools/web_scraper.py
@@ -1,4 +1,5 @@
 from typing import Optional, Dict, Tuple
+import os
 import requests
 from bs4 import BeautifulSoup
 from urllib.parse import urlparse, urljoin
@@ -8,10 +9,10 @@ import time
 from pydantic import BaseModel, Field
 
 _CACHE: Dict[str, Tuple[float, str]] = {}
-_CACHE_TTL = 3600  # seconds
+_CACHE_TTL = int(os.getenv("WEB_SCRAPER_CACHE_TTL", "3600"))
 _ROBOTS: Dict[str, RobotFileParser] = {}
 _LAST_REQUEST_TIME = 0.0
-_DELAY = 1.0  # seconds between requests
+_DELAY = float(os.getenv("WEB_SCRAPER_DELAY", "1.0"))
 
 
 def _respect_delay() -> None:

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -10,11 +10,8 @@ from tkinter import filedialog, messagebox
 from openai import OpenAI
 import docx
 import PyPDF2
-from PIL import Image
 import openpyxl
 import base64
-import io
-from typing import Optional, List, Dict
 from dotenv import load_dotenv
 
 # Load environment variables from .env if present


### PR DESCRIPTION
## Summary
- add `WEB_SCRAPER_CACHE_TTL` and `WEB_SCRAPER_DELAY` options
- document scraper settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bcfaf93848333b4d3b5aa67866ef5