### PR TITLE
Handle no directory in save methods

### DIFF
--- a/src/memory.py
+++ b/src/memory.py
@@ -33,7 +33,9 @@ class ConversationMemory:
 
     def save(self, path: str) -> None:
         """Persist messages to a JSON file."""
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        directory = os.path.dirname(path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             json.dump({"messages": self.messages}, f, ensure_ascii=False, indent=2)
 

--- a/src/vector_memory.py
+++ b/src/vector_memory.py
@@ -31,7 +31,9 @@ class VectorMemory(BaseMemory):
 
     def save(self, path: str) -> None:
         """Persist messages to a JSON file."""
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        directory = os.path.dirname(path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             json.dump({"messages": self.messages}, f, ensure_ascii=False, indent=2)
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -19,3 +19,11 @@ def test_save_creates_directory(tmp_path):
     file = tmp_path / "nested" / "conv.json"
     mem.save(file)
     assert file.exists()
+
+
+def test_save_filename_no_directory(tmp_path, monkeypatch):
+    mem = ConversationMemory()
+    mem.add("user", "hi")
+    monkeypatch.chdir(tmp_path)
+    mem.save("conv.json")
+    assert (tmp_path / "conv.json").exists()

--- a/tests/test_vector_memory.py
+++ b/tests/test_vector_memory.py
@@ -27,3 +27,11 @@ def test_save_creates_directory(tmp_path):
     file = tmp_path / "nested" / "vec.json"
     mem.save(file)
     assert file.exists()
+
+
+def test_save_filename_no_directory(tmp_path, monkeypatch):
+    mem = VectorMemory()
+    mem.add("user", "hello")
+    monkeypatch.chdir(tmp_path)
+    mem.save("vec.json")
+    assert (tmp_path / "vec.json").exists()


### PR DESCRIPTION
## Summary
- guard directory creation in `ConversationMemory.save` and `VectorMemory.save`
- add regression tests ensuring saves work with bare filenames

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c0bdf00448333a45a6ba61bd1fc6f