### PR TITLE
Add logging for title generation errors

### DIFF
--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -347,9 +347,10 @@ class ChatGPTClient:
             self.current_title = response.choices[0].message.content.strip()
             self.window.title(f"ChatGPT Desktop - {self.current_title}")
             
-        except Exception: # エラーハンドリングを少し具体的に
+        except Exception:
+            logging.exception("Failed to generate title")
             self.current_title = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-            self.window.title(f"ChatGPT Desktop - {self.current_title}") # エラー時もタイトル設定
+            self.window.title(f"ChatGPT Desktop - {self.current_title}")  # エラー時もタイトル設定
     
     def save_conversation(self):
         """会話をJSONファイルとして保存"""

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,4 +1,5 @@
 import queue
+import logging
 from types import SimpleNamespace
 
 from src.ui import main as GPT
@@ -45,3 +46,21 @@ def test_get_response_stream(monkeypatch):
         "\n",
         "__SAVE__",
     ]
+
+
+def test_generate_title_logs_error(caplog):
+    client = ChatGPTClient.__new__(ChatGPTClient)
+    client.window = SimpleNamespace(title=lambda *a, **k: None)
+
+    def raise_err(*a, **k):
+        raise RuntimeError("boom")
+
+    client.client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=raise_err))
+    )
+
+    caplog.set_level(logging.ERROR)
+    client.generate_title("hi")
+
+    assert "boom" in caplog.text
+    assert client.current_title


### PR DESCRIPTION
## Summary
- log exceptions thrown during `generate_title` in the UI
- test that errors are logged when title generation fails

## Testing
- `pip install -r requirements.txt -q`
- `pip install -r requirements-dev.txt -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0cea62b08333a8cce2638f6de2f7