### PR TITLE
Refactor scraper settings loading

### DIFF
--- a/src/tools/web_scraper.py
+++ b/src/tools/web_scraper.py
@@ -11,13 +11,25 @@ from pydantic import BaseModel, Field
 
 # Shared state protected by _LOCK
 _CACHE: Dict[str, Tuple[float, str]] = {}
-_CACHE_TTL = int(os.getenv("WEB_SCRAPER_CACHE_TTL", "3600"))
+_CACHE_TTL = 3600
 _ROBOTS: Dict[str, RobotFileParser] = {}
 _LAST_REQUEST_TIME = 0.0
-_DELAY = float(os.getenv("WEB_SCRAPER_DELAY", "1.0"))
+_DELAY = 1.0
 _LOCK = threading.RLock()
 # Default headers for all HTTP requests
-_HEADERS = {"User-Agent": os.getenv("WEB_SCRAPER_USER_AGENT", "Mozilla/5.0")}
+_HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+
+def load_settings() -> None:
+    """Load configuration from environment variables."""
+    global _CACHE_TTL, _DELAY, _HEADERS
+    _CACHE_TTL = int(os.getenv("WEB_SCRAPER_CACHE_TTL", "3600"))
+    _DELAY = float(os.getenv("WEB_SCRAPER_DELAY", "1.0"))
+    _HEADERS = {"User-Agent": os.getenv("WEB_SCRAPER_USER_AGENT", "Mozilla/5.0")}
+
+
+# Initialize settings on import
+load_settings()
 
 
 def _respect_delay() -> None:
@@ -92,6 +104,8 @@ def scrape_website_content(url: str, max_chars: int = 1000) -> str:
 
 
 def get_tool() -> Tool:
+    """Return the web scraper tool with current environment settings."""
+    load_settings()
     return Tool(
         name="web_scraper",
         description="指定されたURLから主要テキストを抽出するツール。入力はURL。",

--- a/tests/test_web_scraper.py
+++ b/tests/test_web_scraper.py
@@ -182,16 +182,16 @@ def test_custom_user_agent(monkeypatch):
     import requests
     monkeypatch.setattr(requests, "get", mock_get)
     monkeypatch.setenv("WEB_SCRAPER_USER_AGENT", expected)
-    # Reload module to pick up env change
-    import importlib
-    importlib.reload(web_scraper)
+    web_scraper._CACHE.clear()
+    web_scraper._ROBOTS.clear()
+    web_scraper.load_settings()
 
     try:
         text = web_scraper.scrape_website_content("http://example.com")
         assert text == "Test"
     finally:
         monkeypatch.delenv("WEB_SCRAPER_USER_AGENT", raising=False)
-        importlib.reload(web_scraper)
+        web_scraper.load_settings()
 
 
 def test_concurrent_calls(monkeypatch):
@@ -224,7 +224,8 @@ def test_concurrent_calls(monkeypatch):
 
     import requests
     monkeypatch.setattr(requests, "get", mock_get)
-    monkeypatch.setattr(web_scraper, "_DELAY", 0)
+    monkeypatch.setenv("WEB_SCRAPER_DELAY", "0")
+    web_scraper.load_settings()
     web_scraper._CACHE.clear()
     web_scraper._ROBOTS.clear()
     web_scraper._LAST_REQUEST_TIME = 0
@@ -244,3 +245,4 @@ def test_concurrent_calls(monkeypatch):
     assert all(r == "Hi" for r in results)
     # robots and page should be fetched once each
     assert call_count["n"] == 2
+    web_scraper.load_settings()


### PR DESCRIPTION
## Summary
- reload web scraper configuration each time `get_tool` is called
- expose `load_settings()` for tests and helpers
- adjust tests to update environment variables without reloading modules

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0de6b64c8333b1db5fd99c4f9638