### PR TITLE
Use env var for default GUI model

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ cp .env.example .env
 echo "OPENAI_API_KEY=your_key_here" >> .env
 ```
 
-`create_llm` reads additional variables if present:
+-`create_llm` reads additional variables if present:
 
-- `OPENAI_MODEL` – default model to use (defaults to `gpt-3.5-turbo`)
+- `OPENAI_MODEL` – default model to use (defaults to `gpt-3.5-turbo`).
+  The GUI also uses this value as the initial model selection and includes
+  `gpt-3.5-turbo` in the drop-down menu.
 - `OPENAI_TOKEN_PRICE` – price per token for usage cost logging
 
 ### 4. Launch the application

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -31,6 +31,10 @@ class ChatGPTClient:
         self.window = ctk.CTk()
         self.window.title("ChatGPT Desktop")
         self.window.geometry("1200x800")
+
+        # モデルの初期値を環境変数から読み込む
+        default_model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+        self.model_var = ctk.StringVar(value=default_model)
         
         # OpenAI クライアントの初期化
         api_key = os.getenv("OPENAI_API_KEY")
@@ -75,12 +79,17 @@ class ChatGPTClient:
                                   font=("SF Pro Display", 14))
         model_label.pack(pady=(20, 5))
         
-        self.model_var = ctk.StringVar(value="gpt-4.1-mini-2025-04-14") # <--- 変更点: デフォルトモデル
-        model_menu = ctk.CTkOptionMenu(left_panel, 
-                                      values=["gpt-4.1-mini-2025-04-14", 
-                                              "gpt-4.1-nano-2025-04-14", 
-                                              "gpt-4.1-2025-04-14"], # <--- 変更点: モデルリスト
-                                      variable=self.model_var, width=250)
+        model_menu = ctk.CTkOptionMenu(
+            left_panel,
+            values=[
+                "gpt-3.5-turbo",
+                "gpt-4.1-mini-2025-04-14",
+                "gpt-4.1-nano-2025-04-14",
+                "gpt-4.1-2025-04-14",
+            ],
+            variable=self.model_var,
+            width=250,
+        )
         model_menu.pack(pady=(0, 20))
         
         # 温度設定


### PR DESCRIPTION
## Summary
- set `ChatGPTClient.model_var` from `OPENAI_MODEL` during init
- include `gpt-3.5-turbo` in the GUI model selector
- note drop-down entry for `gpt-3.5-turbo` in the README

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c92d968608333ba0d3856ec9f60ad