### PR TITLE
Add ToT memory support to CLI

### DIFF
--- a/src/agent/tot_agent.py
+++ b/src/agent/tot_agent.py
@@ -1,5 +1,7 @@
 import re
-from typing import Callable, List, Tuple, Iterator
+from typing import Callable, List, Tuple, Iterator, Optional
+
+from src.memory import BaseMemory
 
 
 class ToTAgent:
@@ -21,6 +23,7 @@ class ToTAgent:
         *,
         max_depth: int = 2,
         breadth: int = 2,
+        memory: Optional[BaseMemory] = None,
     ) -> None:
         """Create a new agent.
 
@@ -39,20 +42,26 @@ class ToTAgent:
         self.evaluate = evaluate
         self.max_depth = max_depth
         self.breadth = breadth
+        self.memory = memory
 
-    def _propose(self, question: str, history: str) -> List[str]:
+    def _propose(self, question: str, history: str, memory: str = "") -> List[str]:
         """Ask the LLM for the next thought candidates."""
         prompt = (
             f"質問: {question}\n"
-            f"これまでの思考:\n{history}\n"
+            + (f"関連履歴:\n{memory}\n" if memory else "")
+            + f"これまでの思考:\n{history}\n"
             f"{self.breadth}個の次の思考候補を箇条書きで提案してください。"
         )
         output = self.llm(prompt)
         return [m.group(1).strip() for m in self.THOUGHT_RE.finditer(output)]
 
-    def _final(self, question: str, history: str) -> str:
+    def _final(self, question: str, history: str, memory: str = "") -> str:
         """Request the final answer from the LLM."""
-        prompt = f"質問: {question}\n思考過程:\n{history}\n最終的な答え:"
+        prompt = (
+            f"質問: {question}\n"
+            + (f"関連履歴:\n{memory}\n" if memory else "")
+            + f"思考過程:\n{history}\n最終的な答え:"
+        )
         resp = self.llm(prompt)
         match = self.FINAL_RE.search(resp)
         return match.group(1).strip() if match else resp.strip()
@@ -66,11 +75,22 @@ class ToTAgent:
         * ``選択`` lines showing which path was chosen and its score
         * a ``最終的な答え`` line containing the answer at the end
         """
+        memory_lines: List[str] = []
+        if self.memory is not None:
+            try:
+                memory_lines = self.memory.search(question, top_k=3)
+            except Exception:
+                memory_lines = []
+            if not memory_lines:
+                memory_lines = [m["content"] for m in self.memory.messages]
+            self.memory.add("user", question)
+        mem_context = "\n".join(memory_lines)
+
         nodes: List[Tuple[str, float]] = [("", 0.0)]
         for _ in range(self.max_depth):
             candidates: List[Tuple[str, float]] = []
             for hist, _score in nodes:
-                thoughts = self._propose(question, hist)
+                thoughts = self._propose(question, hist, mem_context)
                 if thoughts:
                     yield "\n".join(f"思考候補: {t}" for t in thoughts)
                 for t in thoughts:
@@ -83,8 +103,10 @@ class ToTAgent:
             nodes = candidates[: self.breadth]
             yield f"選択: {nodes[0][0]} (score={nodes[0][1]:.2f})"
         best_history = nodes[0][0]
-        answer = self._final(question, best_history)
+        answer = self._final(question, best_history, mem_context)
         yield f"最終的な答え: {answer}"
+        if self.memory is not None:
+            self.memory.add("assistant", answer)
         return
 
     def run(self, question: str) -> str:

--- a/src/main.py
+++ b/src/main.py
@@ -143,11 +143,20 @@ def main(argv: list[str] | None = None) -> None:
         agent = ReActAgent(llm, tools, memory, verbose=args.verbose)
     else:
         evaluator = create_evaluator(llm)
+        memory = VectorMemory() if args.memory == "vector" else ConversationMemory()
+        if args.memory_file and os.path.exists(args.memory_file):
+            try:
+                memory.load(args.memory_file)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to load memory file %s: %s", args.memory_file, exc
+                )
         agent = ToTAgent(
             llm,
             evaluator,
             max_depth=args.depth,
             breadth=args.breadth,
+            memory=memory,
         )
 
     print("Enter an empty line to quit.")

--- a/tests/test_tot_memory_agent.py
+++ b/tests/test_tot_memory_agent.py
@@ -1,0 +1,21 @@
+from src.agent import ToTAgent
+from src.memory import ConversationMemory
+
+
+def test_tot_agent_uses_memory(monkeypatch):
+    mem = ConversationMemory()
+    mem.add("user", "Pythonについて話そう")
+    mem.add("assistant", "はい、Pythonは人気があります")
+
+    prompts = []
+
+    def fake_llm(prompt: str) -> str:
+        prompts.append(prompt)
+        if "箇条書き" in prompt:
+            return "- A"
+        return "最終的な答え: ok"
+
+    agent = ToTAgent(fake_llm, lambda h: 1.0, max_depth=1, breadth=1, memory=mem)
+    answer = agent.run("Pythonの利用例は？")
+    assert answer == "ok"
+    assert "Pythonについて話そう" in prompts[0]


### PR DESCRIPTION
## Summary
- wire memory into `ToTAgent` creation in main CLI
- update CLI tests for new `ToTAgent` argument
- test loading and saving memory when using the ToT agent

## Testing
- `pytest tests/test_main.py::test_main_uses_tot_agent tests/test_main.py::test_main_tot_loads_and_saves_memory -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685cd3ddb21c83338fa1eadb26f4cea8