### PR TITLE
Implement Mermaid diagram tool and streaming tweaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,16 @@
 
 この2部構成のアプローチは、戦略的な整合性を確保しつつ、戦術的な実行の精度を高めるためのベストプラクティスです。戦略と実行を明確に分離することで、開発チームは具体的なコーディング作業に集中でき、プロジェクトマネージャーや技術リーダーは全体像の把握と進捗管理を効率的に行うことが可能となります。本ドキュメントが、単なる計画書としてだけでなく、開発チームにとって実践的かつ再利用可能な技術資産となることを目的としています。
 
+## Codex Instructions
+
+The repository implements a GUI application for ChatGPT using CustomTkinter.
+When modifying this project, keep the following behaviors in mind:
+1. Diagram generation tools `create_graphviz_diagram` and `create_mermaid_diagram` convert DOT or Mermaid code to PNG using external CLI commands.
+2. `ChatGPTClient` exposes these tools via the OpenAI tools API and streams tokens with `stream=True`.
+3. On the first user message, a system prompt instructs the assistant to append prompt advice if the query is vague.
+
+Document further changes to these features in this section so future Codex sessions remain aware of the expected behavior.
+
 ---
 
 ## **パートI：戦略的ブループリントとアーキテクチャの展望（計画）**

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,5 +1,14 @@
 from .web_scraper import get_tool as get_web_scraper
 from .sqlite_tool import get_tool as get_sqlite_tool
+from .mermaid_tool import get_tool as get_mermaid_tool
+from .graphviz_tool import get_tool as get_graphviz_tool
 from .base import Tool, execute_tool
 
-__all__ = ["get_web_scraper", "get_sqlite_tool", "Tool", "execute_tool"]
+__all__ = [
+    "get_web_scraper",
+    "get_sqlite_tool",
+    "get_mermaid_tool",
+    "get_graphviz_tool",
+    "Tool",
+    "execute_tool",
+]

--- a/src/tools/graphviz_tool.py
+++ b/src/tools/graphviz_tool.py
@@ -1,0 +1,41 @@
+import os
+import subprocess
+import tempfile
+from pydantic import BaseModel, Field
+from .base import Tool
+
+class GraphvizInput(BaseModel):
+    code: str = Field(description="DOT言語のコード")
+
+
+def create_graphviz_diagram(dot_code: str) -> str:
+    """Generate a diagram PNG from Graphviz DOT code."""
+    with tempfile.NamedTemporaryFile("w", delete=False, suffix=".dot") as src:
+        src.write(dot_code)
+        src_path = src.name
+    out_file = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
+    out_file.close()
+    try:
+        subprocess.run(
+            ["dot", "-Tpng", src_path, "-o", out_file.name],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        os.unlink(src_path)
+        return "graphviz 'dot' command not found."
+    except subprocess.CalledProcessError as exc:
+        os.unlink(src_path)
+        return f"Failed to generate diagram: {exc.stderr.decode().strip()}"
+    os.unlink(src_path)
+    return out_file.name
+
+
+def get_tool() -> Tool:
+    return Tool(
+        name="create_graphviz_diagram",
+        description="DOT言語から図を生成する。フローチャート等に適している。",
+        func=create_graphviz_diagram,
+        args_schema=GraphvizInput,
+    )

--- a/src/tools/mermaid_tool.py
+++ b/src/tools/mermaid_tool.py
@@ -1,0 +1,42 @@
+import os
+import subprocess
+import tempfile
+from pydantic import BaseModel, Field
+from .base import Tool
+
+class MermaidInput(BaseModel):
+    code: str = Field(description="Mermaid記法のコード")
+
+
+def create_mermaid_diagram(mermaid_code: str) -> str:
+    """Generate a diagram PNG from Mermaid code using the mmdc CLI."""
+    with tempfile.NamedTemporaryFile("w", delete=False, suffix=".mmd") as src:
+        src.write(mermaid_code)
+        src_path = src.name
+    out_file = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
+    out_file.close()
+    try:
+        subprocess.run(
+            ["mmdc", "-i", src_path, "-o", out_file.name],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        os.unlink(src_path)
+        return "mmdc command not found. Install @mermaid-js/mermaid-cli."
+    except subprocess.CalledProcessError as exc:
+        os.unlink(src_path)
+        return f"Failed to generate diagram: {exc.stderr.decode().strip()}"
+    os.unlink(src_path)
+    return out_file.name
+
+
+def get_tool() -> Tool:
+    """Return a Tool for generating diagrams from Mermaid code."""
+    return Tool(
+        name="create_mermaid_diagram",
+        description="Mermaid markdown-like codeから図を生成する。シーケンス図、ガントチャート等に適している。",
+        func=create_mermaid_diagram,
+        args_schema=MermaidInput,
+    )


### PR DESCRIPTION
## Summary
- add Mermaid and Graphviz diagram tools
- expose these tools through `src.tools`
- enhance `ChatGPTClient` with dynamic tool metadata
- inject a system prompt for prompt advice on the first message
- allow streaming API calls to include tools
- document codex instructions in `AGENTS.md`

## Testing
- `pip install -q -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ce3b68998833398525841a8079b16