### PR TITLE
Update README on diagram dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 
 The repository implements a GUI application for ChatGPT using CustomTkinter.
 When modifying this project, keep the following behaviors in mind:
-1. Diagram generation tools `create_graphviz_diagram` and `create_mermaid_diagram` convert DOT or Mermaid code to PNG using external CLI commands.
+1. Diagram generation tools `create_graphviz_diagram` and `create_mermaid_diagram` convert DOT or Mermaid code to PNG using external CLI commands. These features require `Graphviz` (the `dot` command) and the `Mermaid CLI` (`mmdc`) to be installed and accessible in the system `PATH`.
 2. `ChatGPTClient` exposes these tools via the OpenAI tools API and streams tokens with `stream=True`.
 3. On the first user message, a system prompt instructs the assistant to append prompt advice if the query is vague.
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ The window should open allowing you to chat with the model and upload supported 
 ### 5. Install diagram tools
 
 The optional diagram helpers `create_graphviz_diagram` and
-`create_mermaid_diagram` rely on external commands. Install
-`Graphviz` (provides the `dot` command) and the `Mermaid CLI`
-(provides the `mmdc` command) and ensure both are available in your
-`PATH`. On Debian/Ubuntu you can install Graphviz with:
+`create_mermaid_diagram` rely on external CLI programs. `Graphviz`
+provides the `dot` command and the `Mermaid CLI` ships the `mmdc`
+command. Both tools must be installed and available in your `PATH`
+for diagram generation to work. On Debian/Ubuntu you can install
+Graphviz with:
 
 ```bash
 apt install graphviz


### PR DESCRIPTION
## Summary
- emphasize that Graphviz and Mermaid CLI must be installed for diagram helpers
- note dependency requirement in AGENTS instructions

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d1ebef06483338cf4902174231399