### PR TITLE
Add get_default_tools helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,9 @@ When modifying this project, keep the following behaviors in mind:
    as the request timeout when calling the OpenAI API.
 5. `setup_logging` checks the `AGENT_LOG_FILE` environment variable to choose a
    default file for log output.
+6. The command line runner accepts `--list-tools` to print available tool names
+   and descriptions then exit.
+7. `get_default_tools()` returns the built-in tools used by the CLI and tests.
 
 Document further changes to these features in this section so future Codex sessions remain aware of the expected behavior.
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ Display each reasoning step as it happens with `--stream`:
 python -m src.main --stream
 ```
 
+Show the available tools and exit with `--list-tools`:
+
+```bash
+python -m src.main --list-tools
+```
+
 ## Experimental ToT Agent
 
 The repository also ships with a tiny Tree-of-Thoughts agent. It explores

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -4,11 +4,18 @@ from .mermaid_tool import get_tool as get_mermaid_tool
 from .graphviz_tool import get_tool as get_graphviz_tool
 from .base import Tool, execute_tool
 
+
+def get_default_tools() -> list[Tool]:
+    """Return the default built-in tools for the command line interface."""
+
+    return [get_web_scraper(), get_sqlite_tool()]
+
 __all__ = [
     "get_web_scraper",
     "get_sqlite_tool",
     "get_mermaid_tool",
     "get_graphviz_tool",
+    "get_default_tools",
     "Tool",
     "execute_tool",
 ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,6 +23,11 @@ def test_parse_args_stream():
     args = src_main.parse_args(['--stream'])
     assert args.stream
 
+
+def test_parse_args_list_tools():
+    args = src_main.parse_args(['--list-tools'])
+    assert args.list_tools
+
 def test_parse_args_tot_options():
     args = src_main.parse_args(['--agent', 'tot', '--depth', '5', '--breadth', '6'])
     assert args.agent == 'tot'
@@ -79,8 +84,7 @@ def test_main_uses_vector_memory(monkeypatch):
     monkeypatch.setattr(src_main, 'ReActAgent', DummyAgent)
     monkeypatch.setattr(src_main, 'create_llm', lambda log_usage=True: lambda p: 'x')
     monkeypatch.setattr(src_main, 'setup_logging', lambda **k: None)
-    monkeypatch.setattr(src_main, 'get_web_scraper', lambda: None)
-    monkeypatch.setattr(src_main, 'get_sqlite_tool', lambda: None)
+    monkeypatch.setattr(src_main, 'get_default_tools', lambda: [None, None])
     monkeypatch.setattr('builtins.input', lambda prompt='': '')
     monkeypatch.setattr('builtins.print', lambda *a, **k: None)
 
@@ -113,8 +117,7 @@ def test_main_loads_and_saves_memory(tmp_path, monkeypatch):
     monkeypatch.setattr(src_main, 'ReActAgent', DummyAgent)
     monkeypatch.setattr(src_main, 'create_llm', lambda log_usage=True: lambda p: 'x')
     monkeypatch.setattr(src_main, 'setup_logging', lambda **k: None)
-    monkeypatch.setattr(src_main, 'get_web_scraper', lambda: None)
-    monkeypatch.setattr(src_main, 'get_sqlite_tool', lambda: None)
+    monkeypatch.setattr(src_main, 'get_default_tools', lambda: [None, None])
     monkeypatch.setattr(src_main, 'ConversationMemory', DummyMemory)
     monkeypatch.setattr(src_main, 'VectorMemory', DummyMemory)
     monkeypatch.setattr('builtins.input', lambda prompt='': '')
@@ -205,8 +208,7 @@ def test_main_passes_log_file(monkeypatch):
     monkeypatch.setattr(src_main, 'ReActAgent', DummyAgent)
     monkeypatch.setattr(src_main, 'create_llm', lambda log_usage=True: lambda p: 'x')
     monkeypatch.setattr(src_main, 'setup_logging', fake_setup_logging)
-    monkeypatch.setattr(src_main, 'get_web_scraper', lambda: None)
-    monkeypatch.setattr(src_main, 'get_sqlite_tool', lambda: None)
+    monkeypatch.setattr(src_main, 'get_default_tools', lambda: [None, None])
     monkeypatch.setattr('builtins.input', lambda prompt='': '')
     monkeypatch.setattr('builtins.print', lambda *a, **k: None)
 
@@ -230,8 +232,7 @@ def test_main_verbose(monkeypatch):
     monkeypatch.setattr(src_main, 'ReActAgent', DummyAgent)
     monkeypatch.setattr(src_main, 'create_llm', lambda log_usage=True: lambda p: 'x')
     monkeypatch.setattr(src_main, 'setup_logging', fake_setup_logging)
-    monkeypatch.setattr(src_main, 'get_web_scraper', lambda: None)
-    monkeypatch.setattr(src_main, 'get_sqlite_tool', lambda: None)
+    monkeypatch.setattr(src_main, 'get_default_tools', lambda: [None, None])
     monkeypatch.setattr('builtins.input', lambda prompt='': '')
     monkeypatch.setattr('builtins.print', lambda *a, **k: None)
 
@@ -255,8 +256,7 @@ def test_main_stream(monkeypatch):
     monkeypatch.setattr(src_main, 'ReActAgent', DummyAgent)
     monkeypatch.setattr(src_main, 'create_llm', lambda log_usage=True: lambda p: 'x')
     monkeypatch.setattr(src_main, 'setup_logging', lambda **k: None)
-    monkeypatch.setattr(src_main, 'get_web_scraper', lambda: None)
-    monkeypatch.setattr(src_main, 'get_sqlite_tool', lambda: None)
+    monkeypatch.setattr(src_main, 'get_default_tools', lambda: [None, None])
 
     inputs = iter(["hi", ""]) 
     monkeypatch.setattr('builtins.input', lambda prompt='': next(inputs))
@@ -266,4 +266,14 @@ def test_main_stream(monkeypatch):
 
     assert 'step1' in printed
     assert 'step2' in printed
+
+
+def test_main_list_tools(monkeypatch):
+    out = []
+    monkeypatch.setattr('builtins.print', lambda *a, **k: out.append(' '.join(map(str, a))))
+
+    src_main.main(['--list-tools'])
+
+    assert any('web_scraper' in line for line in out)
+    assert any('sqlite_query' in line for line in out)
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,8 @@
+import src.tools as tools
+
+
+def test_get_default_tools():
+    all_names = {t.name for t in tools.get_default_tools()}
+    assert 'web_scraper' in all_names
+    assert 'sqlite_query' in all_names
+


### PR DESCRIPTION
## Summary
- introduce `get_default_tools` for centralizing built-in tools
- use helper in CLI and tests
- document helper in AGENTS notes
- cover helper with new tests

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dcc3a2ecc8333acdd4d9d9e16ea37