### PR TITLE
Clarify Google-style chat colors in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,11 +26,12 @@ When modifying this project, keep the following behaviors in mind:
    and descriptions then exit.
 7. `get_default_tools()` returns the built-in tools used by the CLI and tests.
 8. `get_font_family` checks available system fonts and prefers the Japanese font "Meiryo" if present. If it is missing the helper falls back to "Helvetica." The resulting `FONT_FAMILY` constant is applied across every CustomTkinter widget so the interface uses larger, consistent fonts.
-9. The chat display configures tags `user_msg` (light blue background) and `assistant_msg` (light gray). Incoming, saved and streamed messages are tagged accordingly so each role shows a distinct background color.
+9. The chat display configures tags `user_msg` and `assistant_msg` to style each message type. With the Google-style theme, `user_msg` uses a pale accent blue `#E8F0FE` while `assistant_msg` keeps a light gray `#F1F3F4`. Incoming, saved and streamed messages are tagged accordingly so each role shows a distinct background color.
 10. Diagram images are generated as PNG files but the GUI does not define a dedicated area to display them; the file path is returned as text.
 11. Future updates may add a right-hand sidebar \(or canvas-like panel\) to preview diagrams as they are generated and offer a download link for the PNG file.
 12. The application now includes such a sidebar. When an assistant response contains the path to a PNG file it is automatically loaded and shown in a small preview panel on the right with a "保存" button that lets users choose where to save the image.
 13. A "会話を保存" button in the settings panel lets users manually save the current conversation to the default `conversations` folder. Saving also happens automatically after every assistant response.
+14. The GUI design should adopt a Google-inspired palette and avoid the default `"blue"` theme. Configure a custom theme in `setup_ui()` that uses accent blue `#1A73E8`, left sidebar background `#F1F3F4`, diagram sidebar `#F8F9FA`, and chat area `#FFFFFF`. Text color should remain dark gray `#202124` for readability. Add a geometric window icon via `self.window.iconbitmap()` and adjust widget corner radii and border widths so the interface looks less like stock CustomTkinter.
 
 Document further changes to these features in this section so future Codex sessions remain aware of the expected behavior.
 


### PR DESCRIPTION
## Summary
- clarify chat tag colors in **AGENTS.md** so user messages use pale accent blue `#E8F0FE`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e0145bfc8833392d06ecbdd422f50