### PR TITLE
Apply Google themed CustomTkinter style

### DIFF
--- a/src/ui/google_theme.json
+++ b/src/ui/google_theme.json
@@ -1,0 +1,155 @@
+{
+  "CTk": {
+    "fg_color": ["gray92", "gray14"]
+  },
+  "CTkToplevel": {
+    "fg_color": ["gray92", "gray14"]
+  },
+  "CTkFrame": {
+    "corner_radius": 6,
+    "border_width": 0,
+    "fg_color": ["gray86", "gray17"],
+    "top_fg_color": ["gray81", "gray20"],
+    "border_color": ["gray65", "gray28"]
+  },
+  "CTkButton": {
+    "corner_radius": 6,
+    "border_width": 0,
+    "fg_color": ["#1A73E8", "#1A73E8"],
+    "hover_color": ["#1A73E8", "#1A73E8"],
+    "border_color": ["#3E454A", "#949A9F"],
+    "text_color": ["#DCE4EE", "#DCE4EE"],
+    "text_color_disabled": ["gray74", "gray60"]
+  },
+  "CTkLabel": {
+    "corner_radius": 0,
+    "fg_color": "transparent",
+    "text_color": ["gray10", "#DCE4EE"]
+  },
+  "CTkEntry": {
+    "corner_radius": 6,
+    "border_width": 2,
+    "fg_color": ["#F9F9FA", "#343638"],
+    "border_color": ["#979DA2", "#565B5E"],
+    "text_color":["gray10", "#DCE4EE"],
+    "placeholder_text_color": ["gray52", "gray62"]
+  },
+  "CTkCheckBox": {
+    "corner_radius": 6,
+    "border_width": 3,
+    "fg_color": ["#1A73E8", "#1A73E8"],
+    "border_color": ["#3E454A", "#949A9F"],
+    "hover_color": ["#1A73E8", "#1A73E8"],
+    "checkmark_color": ["#DCE4EE", "gray90"],
+    "text_color": ["gray10", "#DCE4EE"],
+    "text_color_disabled": ["gray60", "gray45"]
+  },
+  "CTkSwitch": {
+    "corner_radius": 1000,
+    "border_width": 3,
+    "button_length": 0,
+    "fg_color": ["#939BA2", "#4A4D50"],
+    "progress_color": ["#1A73E8", "#1A73E8"],
+    "button_color": ["gray36", "#D5D9DE"],
+    "button_hover_color": ["gray20", "gray100"],
+    "text_color": ["gray10", "#DCE4EE"],
+    "text_color_disabled": ["gray60", "gray45"]
+  },
+  "CTkRadioButton": {
+    "corner_radius": 1000,
+    "border_width_checked": 6,
+    "border_width_unchecked": 3,
+    "fg_color": ["#1A73E8", "#1A73E8"],
+    "border_color": ["#3E454A", "#949A9F"],
+    "hover_color": ["#1A73E8", "#1A73E8"],
+    "text_color": ["gray10", "#DCE4EE"],
+    "text_color_disabled": ["gray60", "gray45"]
+  },
+  "CTkProgressBar": {
+    "corner_radius": 1000,
+    "border_width": 0,
+    "fg_color": ["#939BA2", "#4A4D50"],
+    "progress_color": ["#1A73E8", "#1A73E8"],
+    "border_color": ["gray", "gray"]
+  },
+  "CTkSlider": {
+    "corner_radius": 1000,
+    "button_corner_radius": 1000,
+    "border_width": 6,
+    "button_length": 0,
+    "fg_color": ["#939BA2", "#4A4D50"],
+    "progress_color": ["gray40", "#AAB0B5"],
+    "button_color": ["#1A73E8", "#1A73E8"],
+    "button_hover_color": ["#1A73E8", "#1A73E8"]
+  },
+  "CTkOptionMenu": {
+    "corner_radius": 6,
+    "fg_color": ["#1A73E8", "#1A73E8"],
+    "button_color": ["#1A73E8", "#1A73E8"],
+    "button_hover_color": ["#1A73E8", "#1A73E8"],
+    "text_color": ["#DCE4EE", "#DCE4EE"],
+    "text_color_disabled": ["gray74", "gray60"]
+  },
+  "CTkComboBox": {
+    "corner_radius": 6,
+    "border_width": 2,
+    "fg_color": ["#F9F9FA", "#343638"],
+    "border_color": ["#979DA2", "#565B5E"],
+    "button_color": ["#979DA2", "#565B5E"],
+    "button_hover_color": ["#6E7174", "#7A848D"],
+    "text_color": ["gray10", "#DCE4EE"],
+    "text_color_disabled": ["gray50", "gray45"]
+  },
+  "CTkScrollbar": {
+    "corner_radius": 1000,
+    "border_spacing": 4,
+    "fg_color": "transparent",
+    "button_color": ["gray55", "gray41"],
+    "button_hover_color": ["gray40", "gray53"]
+  },
+  "CTkSegmentedButton": {
+    "corner_radius": 6,
+    "border_width": 2,
+    "fg_color": ["#979DA2", "gray29"],
+    "selected_color": ["#1A73E8", "#1A73E8"],
+    "selected_hover_color": ["#1A73E8", "#1A73E8"],
+    "unselected_color": ["#979DA2", "gray29"],
+    "unselected_hover_color": ["gray70", "gray41"],
+    "text_color": ["#DCE4EE", "#DCE4EE"],
+    "text_color_disabled": ["gray74", "gray60"]
+  },
+  "CTkTextbox": {
+    "corner_radius": 6,
+    "border_width": 0,
+    "fg_color": ["#F9F9FA", "#1D1E1E"],
+    "border_color": ["#979DA2", "#565B5E"],
+    "text_color":["gray10", "#DCE4EE"],
+    "scrollbar_button_color": ["gray55", "gray41"],
+    "scrollbar_button_hover_color": ["gray40", "gray53"]
+  },
+  "CTkScrollableFrame": {
+    "label_fg_color": ["gray78", "gray23"]
+  },
+  "DropdownMenu": {
+    "fg_color": ["gray90", "gray20"],
+    "hover_color": ["gray75", "gray28"],
+    "text_color": ["gray10", "gray90"]
+  },
+  "CTkFont": {
+    "macOS": {
+      "family": "SF Display",
+      "size": 13,
+      "weight": "normal"
+    },
+    "Windows": {
+      "family": "Roboto",
+      "size": 13,
+      "weight": "normal"
+    },
+    "Linux": {
+      "family": "Roboto",
+      "size": 13,
+      "weight": "normal"
+    }
+  }
+}

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -44,7 +44,17 @@ logging.basicConfig(
 
 # CustomTkinterの設定
 ctk.set_appearance_mode("light")
-ctk.set_default_color_theme("blue")
+# load custom theme with Google-inspired palette
+THEME_PATH = os.path.join(os.path.dirname(__file__), "google_theme.json")
+ctk.set_default_color_theme(THEME_PATH)
+
+ACCENT_COLOR = "#1A73E8"
+LEFT_SIDEBAR_BG = "#F1F3F4"
+DIAGRAM_SIDEBAR_BG = "#F8F9FA"
+CHAT_BG = "#FFFFFF"
+USER_MSG_BG = "#E8F0FE"
+ASSISTANT_MSG_BG = "#F1F3F4"
+TEXT_COLOR = "#202124"
 
 FONT_FAMILY = get_font_family()
 
@@ -123,7 +133,7 @@ class ChatGPTClient:
         main_container.pack(fill="both", expand=True, padx=20, pady=20)
         
         # 左側パネル（設定）
-        left_panel = ctk.CTkFrame(main_container, width=300, fg_color="#f0f0f0")
+        left_panel = ctk.CTkFrame(main_container, width=300, fg_color=LEFT_SIDEBAR_BG)
         left_panel.pack(side="left", fill="y", padx=(0, 10))
         left_panel.pack_propagate(False)
         
@@ -197,7 +207,7 @@ class ChatGPTClient:
         save_chat_btn.pack(pady=10)
         
         # 右側パネル（図プレビュー）
-        self.diagram_panel = ctk.CTkFrame(main_container, width=250, fg_color="#f9f9f9")
+        self.diagram_panel = ctk.CTkFrame(main_container, width=250, fg_color=DIAGRAM_SIDEBAR_BG)
         self.diagram_panel.pack(side="right", fill="y")
         self.diagram_panel.pack_propagate(False)
 
@@ -214,15 +224,15 @@ class ChatGPTClient:
         self.save_button.pack(pady=(0, 10))
 
         # 右側パネル（チャット）
-        right_panel = ctk.CTkFrame(main_container, fg_color="#ffffff")
+        right_panel = ctk.CTkFrame(main_container, fg_color=CHAT_BG)
         right_panel.pack(side="right", fill="both", expand=True)
         
         # チャットエリア
         self.chat_display = ctk.CTkTextbox(right_panel, font=(FONT_FAMILY, 16),
-                                          wrap="word", fg_color="#f8f8f8")
+                                          wrap="word", fg_color=CHAT_BG)
         self.chat_display.pack(fill="both", expand=True, padx=20, pady=(20, 10))
-        self.chat_display.tag_config("user_msg", background="#e6f7ff")
-        self.chat_display.tag_config("assistant_msg", background="#f5f5f5")
+        self.chat_display.tag_config("user_msg", background=USER_MSG_BG)
+        self.chat_display.tag_config("assistant_msg", background=ASSISTANT_MSG_BG)
         
         # 入力エリア
         input_frame = ctk.CTkFrame(right_panel, fg_color="transparent")


### PR DESCRIPTION
## Summary
- provide a custom `google_theme.json` for CustomTkinter
- load the theme and expose accent/background constants
- apply the new colors in `setup_ui`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_685e0730c6688333b40440c7e409c030