### PR TITLE
Implement Google-inspired theme

### DIFF
--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -44,7 +44,8 @@ logging.basicConfig(
 
 # CustomTkinterの設定
 ctk.set_appearance_mode("light")
-ctk.set_default_color_theme("blue")
+GOOGLE_THEME = os.path.join(os.path.dirname(__file__), "resources", "google.json")
+ctk.set_default_color_theme(GOOGLE_THEME)
 
 ICON_PATH = os.path.join(os.path.dirname(__file__), "resources", "app_icon.xbm")
 
@@ -129,7 +130,13 @@ class ChatGPTClient:
         main_container.pack(fill="both", expand=True, padx=20, pady=20)
         
         # 左側パネル（設定）
-        left_panel = ctk.CTkFrame(main_container, width=300, fg_color="#f0f0f0")
+        left_panel = ctk.CTkFrame(
+            main_container,
+            width=300,
+            fg_color="#F1F3F4",
+            corner_radius=8,
+            border_width=0,
+        )
         left_panel.pack(side="left", fill="y", padx=(0, 10))
         left_panel.pack_propagate(False)
         
@@ -203,7 +210,13 @@ class ChatGPTClient:
         save_chat_btn.pack(pady=10)
         
         # 右側パネル（図プレビュー）
-        self.diagram_panel = ctk.CTkFrame(main_container, width=250, fg_color="#f9f9f9")
+        self.diagram_panel = ctk.CTkFrame(
+            main_container,
+            width=250,
+            fg_color="#F8F9FA",
+            corner_radius=8,
+            border_width=0,
+        )
         self.diagram_panel.pack(side="right", fill="y")
         self.diagram_panel.pack_propagate(False)
 
@@ -220,12 +233,21 @@ class ChatGPTClient:
         self.save_button.pack(pady=(0, 10))
 
         # 右側パネル（チャット）
-        right_panel = ctk.CTkFrame(main_container, fg_color="#ffffff")
+        right_panel = ctk.CTkFrame(
+            main_container,
+            fg_color="#FFFFFF",
+            corner_radius=8,
+            border_width=0,
+        )
         right_panel.pack(side="right", fill="both", expand=True)
         
         # チャットエリア
-        self.chat_display = ctk.CTkTextbox(right_panel, font=(FONT_FAMILY, 16),
-                                          wrap="word", fg_color="#f8f8f8")
+        self.chat_display = ctk.CTkTextbox(
+            right_panel,
+            font=(FONT_FAMILY, 16),
+            wrap="word",
+            fg_color="#FFFFFF",
+        )
         self.chat_display.pack(fill="both", expand=True, padx=20, pady=(20, 10))
         self.chat_display.tag_config("user_msg", background="#E8F0FE")
         self.chat_display.tag_config("assistant_msg", background="#F1F3F4")

--- a/src/ui/resources/google.json
+++ b/src/ui/resources/google.json
@@ -1,0 +1,155 @@
+{
+  "CTk": {
+    "fg_color": ["gray92", "gray14"]
+  },
+  "CTkToplevel": {
+    "fg_color": ["gray92", "gray14"]
+  },
+  "CTkFrame": {
+    "corner_radius": 6,
+    "border_width": 0,
+    "fg_color": ["gray86", "gray17"],
+    "top_fg_color": ["gray81", "gray20"],
+    "border_color": ["gray65", "gray28"]
+  },
+  "CTkButton": {
+    "corner_radius": 6,
+    "border_width": 0,
+    "fg_color": ["#1A73E8", "#174EA6"],
+    "hover_color": ["#1669C1", "#0B59A4"],
+    "border_color": ["#3E454A", "#949A9F"],
+    "text_color": ["#DCE4EE", "#DCE4EE"],
+    "text_color_disabled": ["gray74", "gray60"]
+  },
+  "CTkLabel": {
+    "corner_radius": 0,
+    "fg_color": "transparent",
+    "text_color": ["#202124", "#DCE4EE"]
+  },
+  "CTkEntry": {
+    "corner_radius": 6,
+    "border_width": 2,
+    "fg_color": ["#F9F9FA", "#343638"],
+    "border_color": ["#979DA2", "#565B5E"],
+    "text_color":["#202124", "#DCE4EE"],
+    "placeholder_text_color": ["gray52", "gray62"]
+  },
+  "CTkCheckBox": {
+    "corner_radius": 6,
+    "border_width": 3,
+    "fg_color": ["#1A73E8", "#174EA6"],
+    "border_color": ["#3E454A", "#949A9F"],
+    "hover_color": ["#1A73E8", "#174EA6"],
+    "checkmark_color": ["#DCE4EE", "gray90"],
+    "text_color": ["#202124", "#DCE4EE"],
+    "text_color_disabled": ["gray60", "gray45"]
+  },
+  "CTkSwitch": {
+    "corner_radius": 1000,
+    "border_width": 3,
+    "button_length": 0,
+    "fg_color": ["#939BA2", "#4A4D50"],
+    "progress_color": ["#1A73E8", "#174EA6"],
+    "button_color": ["gray36", "#D5D9DE"],
+    "button_hover_color": ["gray20", "gray100"],
+    "text_color": ["#202124", "#DCE4EE"],
+    "text_color_disabled": ["gray60", "gray45"]
+  },
+  "CTkRadioButton": {
+    "corner_radius": 1000,
+    "border_width_checked": 6,
+    "border_width_unchecked": 3,
+    "fg_color": ["#1A73E8", "#174EA6"],
+    "border_color": ["#3E454A", "#949A9F"],
+    "hover_color": ["#1669C1", "#0B59A4"],
+    "text_color": ["#202124", "#DCE4EE"],
+    "text_color_disabled": ["gray60", "gray45"]
+  },
+  "CTkProgressBar": {
+    "corner_radius": 1000,
+    "border_width": 0,
+    "fg_color": ["#939BA2", "#4A4D50"],
+    "progress_color": ["#1A73E8", "#174EA6"],
+    "border_color": ["gray", "gray"]
+  },
+  "CTkSlider": {
+    "corner_radius": 1000,
+    "button_corner_radius": 1000,
+    "border_width": 6,
+    "button_length": 0,
+    "fg_color": ["#939BA2", "#4A4D50"],
+    "progress_color": ["gray40", "#AAB0B5"],
+    "button_color": ["#1A73E8", "#174EA6"],
+    "button_hover_color": ["#1669C1", "#0B59A4"]
+  },
+  "CTkOptionMenu": {
+    "corner_radius": 6,
+    "fg_color": ["#1A73E8", "#174EA6"],
+    "button_color": ["#1669C1", "#0B59A4"],
+    "button_hover_color": ["#27577D", "#203A4F"],
+    "text_color": ["#DCE4EE", "#DCE4EE"],
+    "text_color_disabled": ["gray74", "gray60"]
+  },
+  "CTkComboBox": {
+    "corner_radius": 6,
+    "border_width": 2,
+    "fg_color": ["#F9F9FA", "#343638"],
+    "border_color": ["#979DA2", "#565B5E"],
+    "button_color": ["#979DA2", "#565B5E"],
+    "button_hover_color": ["#6E7174", "#7A848D"],
+    "text_color": ["#202124", "#DCE4EE"],
+    "text_color_disabled": ["gray50", "gray45"]
+  },
+  "CTkScrollbar": {
+    "corner_radius": 1000,
+    "border_spacing": 4,
+    "fg_color": "transparent",
+    "button_color": ["gray55", "gray41"],
+    "button_hover_color": ["gray40", "gray53"]
+  },
+  "CTkSegmentedButton": {
+    "corner_radius": 6,
+    "border_width": 2,
+    "fg_color": ["#979DA2", "gray29"],
+    "selected_color": ["#1A73E8", "#174EA6"],
+    "selected_hover_color": ["#1669C1", "#0B59A4"],
+    "unselected_color": ["#979DA2", "gray29"],
+    "unselected_hover_color": ["gray70", "gray41"],
+    "text_color": ["#DCE4EE", "#DCE4EE"],
+    "text_color_disabled": ["gray74", "gray60"]
+  },
+  "CTkTextbox": {
+    "corner_radius": 6,
+    "border_width": 0,
+    "fg_color": ["#F9F9FA", "#1D1E1E"],
+    "border_color": ["#979DA2", "#565B5E"],
+    "text_color":["#202124", "#DCE4EE"],
+    "scrollbar_button_color": ["gray55", "gray41"],
+    "scrollbar_button_hover_color": ["gray40", "gray53"]
+  },
+  "CTkScrollableFrame": {
+    "label_fg_color": ["gray78", "gray23"]
+  },
+  "DropdownMenu": {
+    "fg_color": ["gray90", "gray20"],
+    "hover_color": ["gray75", "gray28"],
+    "text_color": ["#202124", "gray90"]
+  },
+  "CTkFont": {
+    "macOS": {
+      "family": "SF Display",
+      "size": 13,
+      "weight": "normal"
+    },
+    "Windows": {
+      "family": "Roboto",
+      "size": 13,
+      "weight": "normal"
+    },
+    "Linux": {
+      "family": "Roboto",
+      "size": 13,
+      "weight": "normal"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `google.json` theme file with accent color #1A73E8 and dark text
- apply new color theme in UI and tweak panel styling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e0f23cbc8833391d6ff1a1bf51b42