### PR TITLE
Add model override option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ When modifying this project, keep the following behaviors in mind:
 13. A "会話を保存" button in the settings panel lets users manually save the current conversation to the default `conversations` folder. Saving also happens automatically after every assistant response.
 14. The GUI design should adopt a Google-inspired palette and avoid the default `"blue"` theme. Configure a custom theme in `setup_ui()` that uses accent blue `#1A73E8`, left sidebar background `#F1F3F4`, diagram sidebar `#F8F9FA`, and chat area `#FFFFFF`. Text color should remain dark gray `#202124` for readability. Add a geometric window icon via `self.window.iconbitmap()` and adjust widget corner radii and border widths so the interface looks less like stock CustomTkinter.
 
+15. The command line runner accepts `--model` to override the default `OPENAI_MODEL` when creating the LLM.
 Document further changes to these features in this section so future Codex sessions remain aware of the expected behavior.
 
 ---

--- a/README.md
+++ b/README.md
@@ -155,6 +155,11 @@ program exits:
 ```bash
 python -m src.main --memory-file chat.json
 ```
+Specify the OpenAI model at runtime with `--model`:
+
+```bash
+python -m src.main --model gpt-4o
+```
 Logs are written to the console by default. Use `--log-file` to also save them
 to a file (or set the `AGENT_LOG_FILE` environment variable):
 

--- a/src/main.py
+++ b/src/main.py
@@ -41,7 +41,7 @@ def _read_tot_env() -> tuple[int | None, int | None]:
     return depth_val, breadth_val
 
 
-def create_llm(*, log_usage: bool = False) -> callable:
+def create_llm(*, log_usage: bool = False, model: str | None = None) -> callable:
     """Create an OpenAI completion callable.
 
     Parameters
@@ -54,7 +54,7 @@ def create_llm(*, log_usage: bool = False) -> callable:
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY not set")
-    model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+    model = model or os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
     token_price = float(os.getenv("OPENAI_TOKEN_PRICE", "0"))
     timeout = float(os.getenv("OPENAI_TIMEOUT", "0")) or None
     client = OpenAI(api_key=api_key)
@@ -151,6 +151,10 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="List available tools and exit",
     )
+    parser.add_argument(
+        "--model",
+        help="OpenAI model name to use (overrides OPENAI_MODEL)",
+    )
     parsed = parser.parse_args(args)
 
     arg_list = args if args is not None else sys.argv[1:]
@@ -176,7 +180,7 @@ def main(argv: list[str] | None = None) -> None:
         for t in get_default_tools():
             print(f"{t.name}: {t.description}")
         return
-    llm = create_llm(log_usage=True)
+    llm = create_llm(log_usage=True, model=args.model)
     memory = None
     tools = None
     if args.agent == "react":


### PR DESCRIPTION
## Summary
- allow overriding `OPENAI_MODEL` from the command line
- document the new `--model` option in instructions and README
- adjust tests for updated `create_llm` signature

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e10e36c28833398b1fa120e49f9f4