### PR TITLE
Silence auto-save popup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ When modifying this project, keep the following behaviors in mind:
 14. The GUI design should adopt a Google-inspired palette and avoid the default `"blue"` theme. Configure a custom theme in `setup_ui()` that uses accent blue `#1A73E8`, left sidebar background `#F1F3F4`, diagram sidebar `#F8F9FA`, and chat area `#FFFFFF`. Text color should remain dark gray `#202124` for readability. Add a geometric window icon via `self.window.iconbitmap()` and adjust widget corner radii and border widths so the interface looks less like stock CustomTkinter.
 
 15. The command line runner accepts `--model` to override the default `OPENAI_MODEL` when creating the LLM.
+16. Automatic conversation saving runs in the background without showing a popup.
 Document further changes to these features in this section so future Codex sessions remain aware of the expected behavior.
 
 ---

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -499,8 +499,8 @@ class ChatGPTClient:
             self.current_title = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
             self.window.title(f"ChatGPT Desktop - {self.current_title}")  # エラー時もタイトル設定
     
-    def save_conversation(self):
-        """会話をJSONファイルとして保存"""
+    def save_conversation(self, show_popup: bool = True):
+        """会話をJSONファイルとして保存."""
         if not self.current_title:
             return
         
@@ -532,12 +532,16 @@ class ChatGPTClient:
         try:
             with open(filename, 'w', encoding='utf-8') as f:
                 json.dump(conversation_data, f, ensure_ascii=False, indent=2)
-            try:
-                messagebox.showinfo("保存完了", f"会話を {filename} に保存しました")
-            except tkinter.TclError:
-                pass
+            if show_popup:
+                try:
+                    messagebox.showinfo("保存完了", f"会話を {filename} に保存しました")
+                except tkinter.TclError:
+                    pass
         except Exception as e:
-            messagebox.showerror("保存エラー", f"会話の保存に失敗しました: {str(e)}")
+            if show_popup:
+                messagebox.showerror("保存エラー", f"会話の保存に失敗しました: {str(e)}")
+            else:
+                logging.error("会話の保存に失敗しました: %s", e)
 
     
     def new_chat(self):
@@ -634,7 +638,7 @@ class ChatGPTClient:
                     self.display_diagram(item[len("__DIAGRAM__"):])
                     continue
                 if item == "__SAVE__":
-                    self.save_conversation()
+                    self.save_conversation(show_popup=False)
                     continue
                 self.chat_display.configure(state="normal")
                 if item.startswith("🤖 Assistant: "):


### PR DESCRIPTION
## Summary
- keep popup for manual save and skip it for automatic background saves
- document new behavior in `AGENTS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e71985324833391d78446d5ce0d04