### PR TITLE
Integrate agents and switch diagrams to python libs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 
 The repository implements a GUI application for ChatGPT using CustomTkinter.
 When modifying this project, keep the following behaviors in mind:
-1. Diagram generation tools `create_graphviz_diagram` and `create_mermaid_diagram` convert DOT or Mermaid code to PNG using external CLI commands. These features require `Graphviz` (the `dot` command) and the `Mermaid CLI` (`mmdc`) to be installed and accessible in the system `PATH`.
+1. Diagram generation tools `create_graphviz_diagram` and `create_mermaid_diagram` convert DOT or Mermaid code to PNG using Python libraries. `graphviz` renders DOT files and `mermaid-py` sends code to the Mermaid Live server to obtain PNG output, so no external CLI commands are required.
 2. `ChatGPTClient` exposes these tools via the OpenAI tools API and streams tokens with `stream=True`.
 3. On the first user message, a system prompt instructs the assistant to append prompt advice if the query is vague.
 4. `create_llm` reads an optional `OPENAI_TIMEOUT` environment variable and passes it

--- a/README.md
+++ b/README.md
@@ -65,24 +65,14 @@ The left settings panel offers controls to:
 - Start a new conversation or load a previous one
 - **Save the current conversation** at any time using the "会話を保存" button
 
-### 5. Install diagram tools
+### 5. Install diagram libraries
 
 The optional diagram helpers `create_graphviz_diagram` and
-`create_mermaid_diagram` rely on external CLI programs. `Graphviz`
-provides the `dot` command and the `Mermaid CLI` ships the `mmdc`
-command. Both tools must be installed and available in your `PATH`
-for diagram generation to work. On Debian/Ubuntu you can install
-Graphviz with:
-
-```bash
-apt install graphviz
-```
-
-And install the Mermaid CLI globally using npm:
-
-```bash
-npm install -g @mermaid-js/mermaid-cli
-```
+`create_mermaid_diagram` now use the `graphviz` and `mermaid-py`
+packages to generate PNG files directly from code. No external CLI
+commands are required, but Graphviz must be installed on the system for
+`graphviz` to work and `mermaid-py` contacts the Mermaid Live server to
+render images.
 
 ### Diagram preview sidebar
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ beautifulsoup4
 pydantic
 
 scikit-learn
+graphviz
+mermaid-py

--- a/src/tools/graphviz_tool.py
+++ b/src/tools/graphviz_tool.py
@@ -1,6 +1,5 @@
-import os
-import subprocess
 import tempfile
+from graphviz import Source
 from pydantic import BaseModel, Field
 from .base import Tool
 
@@ -9,26 +8,15 @@ class GraphvizInput(BaseModel):
 
 
 def create_graphviz_diagram(dot_code: str) -> str:
-    """Generate a diagram PNG from Graphviz DOT code."""
-    with tempfile.NamedTemporaryFile("w", delete=False, suffix=".dot") as src:
-        src.write(dot_code)
-        src_path = src.name
+    """Generate a diagram PNG from Graphviz DOT code using the graphviz package."""
     out_file = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
     out_file.close()
     try:
-        subprocess.run(
-            ["dot", "-Tpng", src_path, "-o", out_file.name],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-    except FileNotFoundError:
-        os.unlink(src_path)
-        return "graphviz 'dot' command not found."
-    except subprocess.CalledProcessError as exc:
-        os.unlink(src_path)
-        return f"Failed to generate diagram: {exc.stderr.decode().strip()}"
-    os.unlink(src_path)
+        src = Source(dot_code)
+        src.format = "png"
+        src.render(out_file.name, cleanup=True)
+    except Exception as exc:
+        return f"Failed to generate diagram: {exc}"
     return out_file.name
 
 

--- a/src/tools/mermaid_tool.py
+++ b/src/tools/mermaid_tool.py
@@ -1,6 +1,5 @@
-import os
-import subprocess
 import tempfile
+from mermaid import Mermaid
 from pydantic import BaseModel, Field
 from .base import Tool
 
@@ -9,26 +8,14 @@ class MermaidInput(BaseModel):
 
 
 def create_mermaid_diagram(mermaid_code: str) -> str:
-    """Generate a diagram PNG from Mermaid code using the mmdc CLI."""
-    with tempfile.NamedTemporaryFile("w", delete=False, suffix=".mmd") as src:
-        src.write(mermaid_code)
-        src_path = src.name
+    """Generate a diagram PNG from Mermaid code using mermaid-py."""
     out_file = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
     out_file.close()
     try:
-        subprocess.run(
-            ["mmdc", "-i", src_path, "-o", out_file.name],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-    except FileNotFoundError:
-        os.unlink(src_path)
-        return "mmdc command not found. Install @mermaid-js/mermaid-cli."
-    except subprocess.CalledProcessError as exc:
-        os.unlink(src_path)
-        return f"Failed to generate diagram: {exc.stderr.decode().strip()}"
-    os.unlink(src_path)
+        diagram = Mermaid(mermaid_code)
+        diagram.to_png(out_file.name)
+    except Exception as exc:
+        return f"Failed to generate diagram: {exc}"
     return out_file.name
 
 

--- a/tests/test_prompt_advice.py
+++ b/tests/test_prompt_advice.py
@@ -16,6 +16,7 @@ def _client():
     c.generate_title = lambda m: None
     c.get_response = lambda: None
     c.response_queue = queue.Queue()
+    c.agent_var = SimpleNamespace(get=lambda: "chatgpt")
     return c
 
 


### PR DESCRIPTION
## Summary
- use `graphviz` and `mermaid-py` instead of external CLIs
- expose agent selection in the GUI and implement `run_agent`
- update tests for new diagram helpers
- document new behavior in `AGENTS.md` and README

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869d2d8fb58833387bf6d30a62986cb