### PR TITLE
Implement diagram clear button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,11 +30,12 @@ When modifying this project, keep the following behaviors in mind:
 10. Diagram images are generated as PNG files but the GUI does not define a dedicated area to display them; the file path is returned as text.
 11. Future updates may add a right-hand sidebar \(or canvas-like panel\) to preview diagrams as they are generated and offer a download link for the PNG file.
 12. The application now includes such a sidebar. When an assistant response contains the path to a PNG file it is automatically loaded and shown in a small preview panel on the right with a "保存" button that lets users choose where to save the image.
-13. A "会話を保存" button in the settings panel lets users manually save the current conversation to the default `conversations` folder. Saving also happens automatically after every assistant response.
-14. The GUI design should adopt a Google-inspired palette and avoid the default `"blue"` theme. Configure a custom theme in `setup_ui()` that uses accent blue `#1A73E8`, left sidebar background `#F1F3F4`, diagram sidebar `#F8F9FA`, and chat area `#FFFFFF`. Text color should remain dark gray `#202124` for readability. Add a geometric window icon via `self.window.iconbitmap()` and adjust widget corner radii and border widths so the interface looks less like stock CustomTkinter.
+13. The sidebar also provides a "クリア" button that removes the preview and disables saving when no image is shown.
+14. A "会話を保存" button in the settings panel lets users manually save the current conversation to the default `conversations` folder. Saving also happens automatically after every assistant response.
+15. The GUI design should adopt a Google-inspired palette and avoid the default `"blue"` theme. Configure a custom theme in `setup_ui()` that uses accent blue `#1A73E8`, left sidebar background `#F1F3F4`, diagram sidebar `#F8F9FA`, and chat area `#FFFFFF`. Text color should remain dark gray `#202124` for readability. Add a geometric window icon via `self.window.iconbitmap()` and adjust widget corner radii and border widths so the interface looks less like stock CustomTkinter.
 
-15. The command line runner accepts `--model` to override the default `OPENAI_MODEL` when creating the LLM.
-16. Automatic conversation saving runs in a background thread without showing a popup so the UI remains responsive.
+16. The command line runner accepts `--model` to override the default `OPENAI_MODEL` when creating the LLM.
+17. Automatic conversation saving runs in a background thread without showing a popup so the UI remains responsive.
 Document further changes to these features in this section so future Codex sessions remain aware of the expected behavior.
 
 ---

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -263,6 +263,15 @@ class ChatGPTClient:
         )
         self.save_button.pack(pady=(0, 10))
 
+        self.clear_button = ctk.CTkButton(
+            self.diagram_panel,
+            text="クリア",
+            command=lambda: self.clear_diagram(),
+            font=(FONT_FAMILY, 14),
+            state="disabled",
+        )
+        self.clear_button.pack(pady=(0, 10))
+
         # 右側パネル（チャット）
         right_panel = ctk.CTkFrame(
             main_container,
@@ -685,6 +694,7 @@ class ChatGPTClient:
         self.diagram_label.configure(image=preview, text="")
         self.diagram_label.image = preview
         self.save_button.configure(state="normal")
+        self.clear_button.configure(state="normal")
         self._diagram_path = path
 
     def save_diagram(self) -> None:
@@ -697,6 +707,14 @@ class ChatGPTClient:
                 shutil.copy(self._diagram_path, dest)
             except Exception as exc:
                 messagebox.showerror("保存エラー", str(exc))
+
+    def clear_diagram(self) -> None:
+        """Remove the current diagram preview and disable related buttons."""
+        self.diagram_label.configure(image=None, text="図のプレビュー")
+        self.diagram_label.image = None
+        self.save_button.configure(state="disabled")
+        self.clear_button.configure(state="disabled")
+        self._diagram_path = None
 
     def process_queue(self):
         """キューからのメッセージをGUIに反映"""

--- a/tests/test_diagram_preview.py
+++ b/tests/test_diagram_preview.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+from src.ui import main as GPT
+
+ChatGPTClient = GPT.ChatGPTClient
+
+
+def _client():
+    c = ChatGPTClient.__new__(ChatGPTClient)
+    c.diagram_label = SimpleNamespace(configure=lambda **k: c.calls.setdefault('label', []).append(k), image=None)
+    c.save_button = SimpleNamespace(configure=lambda **k: c.calls.setdefault('save', []).append(k))
+    c.clear_button = SimpleNamespace(configure=lambda **k: c.calls.setdefault('clear', []).append(k))
+    c.calls = {}
+    return c
+
+
+def test_display_and_clear_diagram(monkeypatch, tmp_path):
+    client = _client()
+    img = tmp_path / "d.png"
+    img.write_bytes(b'x')
+    monkeypatch.setattr(GPT.Image, 'open', lambda path: object())
+    monkeypatch.setattr(GPT.ctk, 'CTkImage', lambda light_image, size: object())
+
+    client.display_diagram(str(img))
+    assert client._diagram_path == str(img)
+    assert any(k.get('state') == 'normal' for k in client.calls.get('save', []))
+    assert any(k.get('state') == 'normal' for k in client.calls.get('clear', []))
+
+    client.calls = {'label': [], 'save': [], 'clear': []}
+    client.clear_diagram()
+    assert client._diagram_path is None
+    assert any(k.get('state') == 'disabled' for k in client.calls.get('save', []))
+    assert any(k.get('state') == 'disabled' for k in client.calls.get('clear', []))


### PR DESCRIPTION
## Summary
- add a clear button to remove diagram previews
- document the new behavior in `AGENTS.md`
- test diagram preview clearing logic

## Testing
- `pip install -r requirements.txt -q`
- `pip install -r requirements-dev.txt -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e9c79538833389c35a35623faf3e