### PR TITLE
Fix timeout parsing

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -56,7 +56,12 @@ def create_llm(*, log_usage: bool = False, model: str | None = None) -> callable
         raise RuntimeError("OPENAI_API_KEY not set")
     model = model or os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
     token_price = float(os.getenv("OPENAI_TOKEN_PRICE", "0"))
-    timeout = float(os.getenv("OPENAI_TIMEOUT", "0")) or None
+    timeout_str = os.getenv("OPENAI_TIMEOUT", "0")
+    try:
+        timeout = float(timeout_str) or None
+    except ValueError:
+        logger.warning("Invalid OPENAI_TIMEOUT=%s, using default", timeout_str)
+        timeout = None
     client = OpenAI(api_key=api_key)
 
     def llm(prompt: str) -> str:

--- a/tests/test_usage_logging.py
+++ b/tests/test_usage_logging.py
@@ -37,3 +37,13 @@ def test_create_llm_timeout(monkeypatch):
     llm = src_main.create_llm()
     llm("hi")
     assert dummy.last_kwargs.get("timeout") == 5.0
+
+
+def test_create_llm_bad_timeout(monkeypatch):
+    dummy = DummyClient()
+    monkeypatch.setattr(src_main, "OpenAI", lambda api_key: dummy)
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setenv("OPENAI_TIMEOUT", "oops")
+    llm = src_main.create_llm()
+    llm("hi")
+    assert "timeout" not in dummy.last_kwargs


### PR DESCRIPTION
## Summary
- handle invalid `OPENAI_TIMEOUT` values in `create_llm`
- test invalid timeout handling

## Testing
- `pytest tests/test_usage_logging.py::test_create_llm_bad_timeout -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869f6d59820833394cd5c8a2481097d