### PR TITLE
Add diagram save confirmation

### DIFF
--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -707,6 +707,8 @@ class ChatGPTClient:
                 shutil.copy(self._diagram_path, dest)
             except Exception as exc:
                 messagebox.showerror("保存エラー", str(exc))
+            else:
+                messagebox.showinfo("保存完了", f"図を {dest} に保存しました")
 
     def clear_diagram(self) -> None:
         """Remove the current diagram preview and disable related buttons."""

--- a/tests/test_diagram_preview.py
+++ b/tests/test_diagram_preview.py
@@ -30,3 +30,22 @@ def test_display_and_clear_diagram(monkeypatch, tmp_path):
     assert client._diagram_path is None
     assert any(k.get('state') == 'disabled' for k in client.calls.get('save', []))
     assert any(k.get('state') == 'disabled' for k in client.calls.get('clear', []))
+
+
+def test_save_diagram(monkeypatch, tmp_path):
+    client = _client()
+    src = tmp_path / "src.png"
+    src.write_bytes(b'x')
+    client._diagram_path = str(src)
+
+    dest = tmp_path / "out.png"
+    monkeypatch.setattr(GPT.filedialog, 'asksaveasfilename', lambda **k: str(dest))
+    monkeypatch.setattr(GPT.shutil, 'copy', lambda s, d: dest.write_bytes(b'y'))
+    info_calls = []
+    monkeypatch.setattr(GPT.messagebox, 'showinfo', lambda *a, **k: info_calls.append(a))
+    monkeypatch.setattr(GPT.messagebox, 'showerror', lambda *a, **k: None)
+
+    client.save_diagram()
+
+    assert dest.exists()
+    assert info_calls


### PR DESCRIPTION
## Summary
- show a messagebox on successful diagram saves
- test that save_diagram triggers the confirmation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869f9f06f148333b57b96af1e596674