### PR TITLE
Fix new_chat memory reset

### DIFF
--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -627,7 +627,14 @@ class ChatGPTClient:
         self.messages = []
         self.current_title = None
         self.uploaded_files = []
-        
+        try:
+            if isinstance(self.memory, ConversationMemory):
+                self.memory = ConversationMemory()
+            elif hasattr(self.memory, "messages"):
+                self.memory.messages.clear()
+        except Exception:
+            logging.warning("Failed to reset memory", exc_info=True)
+
         self.chat_display.configure(state="normal")
         self.chat_display.delete("1.0", "end")
         self.chat_display.insert("1.0", "新しい会話を開始しました。\n")

--- a/tests/test_new_chat.py
+++ b/tests/test_new_chat.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+
+from src.ui import main as GPT
+from src.memory import ConversationMemory
+
+ChatGPTClient = GPT.ChatGPTClient
+
+
+def _client():
+    c = ChatGPTClient.__new__(ChatGPTClient)
+    c.memory = ConversationMemory()
+    c.memory.add("user", "hi")
+    c.chat_display = SimpleNamespace(configure=lambda *a, **k: None,
+                                     delete=lambda *a, **k: None,
+                                     insert=lambda *a, **k: None)
+    c.file_list_text = SimpleNamespace(configure=lambda *a, **k: None,
+                                       delete=lambda *a, **k: None)
+    c.window = SimpleNamespace(title=lambda *a, **k: None)
+    return c
+
+
+def test_new_chat_clears_memory():
+    client = _client()
+    assert client.memory.messages
+    client.new_chat()
+    assert client.memory.messages == []


### PR DESCRIPTION
## Summary
- reset the conversation memory when starting a new chat
- add regression test ensuring `ChatGPTClient.new_chat` clears memory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a043ec6a08333be305cb2f4736e24