### PR TITLE
Add test for font fallback

### DIFF
--- a/tests/test_get_font_family.py
+++ b/tests/test_get_font_family.py
@@ -1,0 +1,9 @@
+import tkinter
+from src.ui import main as GPT
+
+
+def test_get_font_family_tclerror(monkeypatch):
+    def raise_tclerror(*args, **kwargs):
+        raise tkinter.TclError('no display')
+    monkeypatch.setattr(tkinter, 'Tk', raise_tclerror)
+    assert GPT.get_font_family() == "Helvetica"


### PR DESCRIPTION
## Summary
- test `get_font_family()` error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a07d746848333a77f7d2498b3ebbe