### PR TITLE
Add tool call streaming support

### DIFF
--- a/tests/test_save_conversation.py
+++ b/tests/test_save_conversation.py
@@ -32,3 +32,35 @@ def test_save_conversation(tmp_path, monkeypatch):
     assert data["messages"] == client.messages
     assert data["uploaded_files_metadata"] == [{"name": "file.docx", "type": ".docx"}]
     assert "timestamp" in data
+
+
+def test_save_conversation_with_tool(tmp_path, monkeypatch):
+    client = _client()
+    client.current_title = "ToolChat"
+    client.model_var = SimpleNamespace(get=lambda: "model-x")
+    client.messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "1", "content": "path"},
+    ]
+    client.uploaded_files = []
+    monkeypatch.setattr(GPT.messagebox, 'showinfo', lambda *a, **k: None)
+    monkeypatch.setattr(GPT.messagebox, 'showerror', lambda *a, **k: None)
+    monkeypatch.chdir(tmp_path)
+    client.save_conversation()
+
+    conv_dir = tmp_path / "conversations"
+    files = list(conv_dir.glob("*.json"))
+    with open(files[0], "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert data["messages"] == client.messages

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -21,14 +21,26 @@ def test_get_response_stream(monkeypatch):
 
     def create(model, messages, temperature, stream=True):
         assert stream
-        parts = [
-            "Hello",
-            " world",
-            None,
-        ]
         return [
-            SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content=p))])
-            for p in parts
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content="Hello"), finish_reason=None
+                    )
+                ]
+            ),
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content=" world"), finish_reason=None
+                    )
+                ]
+            ),
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(delta=SimpleNamespace(content=None), finish_reason="stop")
+                ]
+            ),
         ]
 
     client.client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
@@ -64,3 +76,60 @@ def test_generate_title_logs_error(caplog):
 
     assert "boom" in caplog.text
     assert client.current_title
+
+
+def test_get_response_tool_calls(monkeypatch):
+    client = _client()
+
+    call = {"count": 0}
+
+    def create(model, messages, temperature, stream=True, tools=None, tool_choice=None):
+        call["count"] += 1
+        if call["count"] == 1:
+            tc = SimpleNamespace(
+                id="1",
+                function=SimpleNamespace(
+                    name="create_graphviz_diagram",
+                    arguments='{"code": "digraph {a->b}"}'
+                ),
+            )
+            return [
+                SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            delta=SimpleNamespace(tool_calls=[tc]),
+                            finish_reason="tool_calls",
+                        )
+                    ]
+                )
+            ]
+        parts = ["done", None]
+        return [
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content=p),
+                        finish_reason=None if p else "stop",
+                    )
+                ]
+            )
+            for p in parts
+        ]
+
+    client.client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    client.tool_funcs = {"create_graphviz_diagram": lambda code: "/tmp/x.png"}
+    client.tools = [{"type": "function", "function": {"name": "create_graphviz_diagram"}}]
+
+    client.get_response()
+
+    out = []
+    while not client.response_queue.empty():
+        out.append(client.response_queue.get())
+
+    assert out[0] == "🤖 Assistant: "
+    assert "done" in "".join(out)
+    assert client.messages[1]["role"] == "assistant"
+    assert client.messages[2]["role"] == "tool"
+    assert client.messages[2]["content"] == "/tmp/x.png"
+    assert client.messages[-1]["role"] == "assistant"
+    assert client.messages[-1]["content"] == "done"


### PR DESCRIPTION
## Summary
- stream tool calls from `get_response` and execute tools
- support saving conversations with tool outputs
- test streaming tool call handling
- test saving conversations with tool results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a110203e88333b65908b924bf4fd8