### PR TITLE
Remove obsolete tool_funcs mapping

### DIFF
--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -43,6 +43,12 @@ from src.tools import (
 from src.tools.graphviz_tool import create_graphviz_diagram
 from src.tools.mermaid_tool import create_mermaid_diagram
 
+# Mapping of tool names to implementation functions
+TOOL_FUNCS = {
+    "create_graphviz_diagram": create_graphviz_diagram,
+    "create_mermaid_diagram": create_mermaid_diagram,
+}
+
 # Load environment variables from .env if present
 load_dotenv()
 
@@ -132,10 +138,6 @@ class ChatGPTClient:
                 },
             },
         ]
-        self.tool_funcs = {
-            "create_graphviz_diagram": create_graphviz_diagram,
-            "create_mermaid_diagram": create_mermaid_diagram,
-        }
         
         # UI要素の作成
         self.setup_ui()
@@ -537,7 +539,7 @@ class ChatGPTClient:
                     self.messages.append(assistant_msg)
 
                     for cid, d in tool_data.items():
-                        func = self.tool_funcs.get(d["name"])
+                        func = TOOL_FUNCS.get(d["name"])
                         if func:
                             try:
                                 args = json.loads(d["args"] or "{}")

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -117,7 +117,7 @@ def test_get_response_tool_calls(monkeypatch):
         ]
 
     client.client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
-    client.tool_funcs = {"create_graphviz_diagram": lambda code: "/tmp/x.png"}
+    monkeypatch.setattr(GPT, "TOOL_FUNCS", {"create_graphviz_diagram": lambda code: "/tmp/x.png"})
     client.tools = [{"type": "function", "function": {"name": "create_graphviz_diagram"}}]
 
     client.get_response()


### PR DESCRIPTION
## Summary
- remove `self.tool_funcs` from `ChatGPTClient`
- map tool functions with module constant `TOOL_FUNCS`
- adjust streaming tests for new constant

## Testing
- `pip install -q -r requirements.txt -r requirements-dev.txt`
- `pytest -q`
- `python -m src.ui.main` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_686a2da0894483339e4eea259696d084