### PR TITLE
Fix import ordering

### DIFF
--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -1,16 +1,16 @@
-import os
-import json
+import base64
 import datetime
-import threading
+import json
 import logging
+import os
 import queue
 import re
 import shutil
-import base64
+import threading
 
 import customtkinter as ctk
-from tkinter import filedialog, messagebox
 import tkinter
+from tkinter import filedialog, messagebox
 from PIL import Image
 import docx
 import PyPDF2


### PR DESCRIPTION
## Summary
- rearrange imports at module top so that OpenAI and document-handling libraries precede function definitions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a41f5cc6c8333b1e665b875bbfe08