### PR TITLE
Refactor memory classes

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface."""
 
-from .memory import ConversationMemory, BaseMemory
+from .memory import ConversationMemory, MessageMemory, BaseMemory
 from .vector_memory import VectorMemory
 from .agent import ReActAgent, ToTAgent
 from .tools import get_web_scraper, get_sqlite_tool, Tool, execute_tool
@@ -9,6 +9,7 @@ from .logging_utils import setup_logging
 __all__ = [
     "ConversationMemory",
     "VectorMemory",
+    "MessageMemory",
     "BaseMemory",
     "ReActAgent",
     "ToTAgent",

--- a/src/memory.py
+++ b/src/memory.py
@@ -21,9 +21,10 @@ class BaseMemory(Protocol):
     def search(self, query: str, top_k: int = 3) -> List[str]:
         ...
 
+
 @dataclass
-class ConversationMemory:
-    """Simple in-memory store for conversation messages."""
+class MessageMemory:
+    """Common message storage with persistence helpers."""
 
     messages: List[Dict[str, str]] = field(default_factory=list)
 
@@ -44,6 +45,11 @@ class ConversationMemory:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
         self.messages = data.get("messages", [])
+
+
+@dataclass
+class ConversationMemory(MessageMemory):
+    """Simple in-memory store for conversation messages."""
 
     def search(self, query: str, top_k: int = 3) -> List[str]:
         """Return messages containing the query text."""

--- a/src/vector_memory.py
+++ b/src/vector_memory.py
@@ -1,22 +1,16 @@
 from dataclasses import dataclass, field
 from typing import List, Dict
-import json
-import os
 
-from .memory import BaseMemory
+from .memory import MessageMemory
 
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 
 @dataclass
-class VectorMemory(BaseMemory):
+class VectorMemory(MessageMemory):
     """Conversation memory backed by a simple vector store using TF-IDF."""
 
     messages: List[Dict[str, str]] = field(default_factory=list)
-
-    def add(self, role: str, content: str) -> None:
-        """Add a message to memory."""
-        self.messages.append({"role": role, "content": content})
 
     def search(self, query: str, top_k: int = 3) -> List[str]:
         """Return the contents of the messages most similar to the query."""
@@ -29,16 +23,3 @@ class VectorMemory(BaseMemory):
         indices = sims.argsort()[::-1][:top_k]
         return [corpus[i] for i in indices]
 
-    def save(self, path: str) -> None:
-        """Persist messages to a JSON file."""
-        directory = os.path.dirname(path)
-        if directory:
-            os.makedirs(directory, exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
-            json.dump({"messages": self.messages}, f, ensure_ascii=False, indent=2)
-
-    def load(self, path: str) -> None:
-        """Load messages from a JSON file."""
-        with open(path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-        self.messages = data.get("messages", [])


### PR DESCRIPTION
## Summary
- centralize message persistence logic in new `MessageMemory`
- derive `ConversationMemory` and `VectorMemory` from `MessageMemory`
- expose `MessageMemory` via `src.__all__`

## Testing
- `pip install -q -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a47a9f5348333b66fd5951642f2c2