### PR TITLE
Add configurable conversation directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ When modifying this project, keep the following behaviors in mind:
 11. Future updates may add a right-hand sidebar \(or canvas-like panel\) to preview diagrams as they are generated and offer a download link for the PNG file.
 12. The application now includes such a sidebar. When an assistant response contains the path to a PNG file it is automatically loaded and shown in a small preview panel on the right with a "保存" button that lets users choose where to save the image.
 13. The sidebar also provides a "クリア" button that removes the preview and disables saving when no image is shown.
-14. A "会話を保存" button in the settings panel lets users manually save the current conversation to the default `conversations` folder. Saving also happens automatically after every assistant response.
+14. A "会話を保存" button in the settings panel lets users manually save the current conversation to a JSON file. The directory defaults to `conversations` but can be overridden with the `CONVERSATION_DIR` environment variable. Saving also happens automatically after every assistant response.
 15. The GUI design should adopt a Google-inspired palette and avoid the default `"blue"` theme. Configure a custom theme in `setup_ui()` that uses accent blue `#1A73E8`, left sidebar background `#F1F3F4`, diagram sidebar `#F8F9FA`, and chat area `#FFFFFF`. Text color should remain dark gray `#202124` for readability. Add a geometric window icon via `self.window.iconbitmap()` and adjust widget corner radii and border widths so the interface looks less like stock CustomTkinter.
 
 16. The command line runner accepts `--model` to override the default `OPENAI_MODEL` when creating the LLM.

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -74,6 +74,9 @@ TOOL_FUNCS = {
 # Load environment variables from .env if present
 load_dotenv()
 
+# Default directory for saving conversations
+CONV_DIR = os.getenv("CONVERSATION_DIR", "conversations")
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
@@ -743,13 +746,13 @@ class ChatGPTClient:
             return
         
         # conversationsディレクトリがなければ作成
-        if not os.path.exists("conversations"):
-            os.makedirs("conversations")
+        if not os.path.exists(CONV_DIR):
+            os.makedirs(CONV_DIR)
             
         filename_base = f"{self.current_title}_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}"
         # ファイル名に使えない文字を置換
         filename_safe = "".join(c if c.isalnum() or c in (' ', '-', '_') else '_' for c in filename_base)
-        filename = os.path.join("conversations", f"{filename_safe}.json")
+        filename = os.path.join(CONV_DIR, f"{filename_safe}.json")
         
         # uploaded_filesのcontentは保存しない (大きすぎる可能性があるため)
         files_metadata = []
@@ -809,6 +812,7 @@ class ChatGPTClient:
         file_path = filedialog.askopenfilename(
             title="会話を選択",
             filetypes=[("Conversation", "*.json")],
+            initialdir=CONV_DIR,
         )
         if file_path:
             self.load_conversation(file_path)

--- a/tests/test_save_conversation.py
+++ b/tests/test_save_conversation.py
@@ -64,3 +64,20 @@ def test_save_conversation_with_tool(tmp_path, monkeypatch):
         data = json.load(f)
 
     assert data["messages"] == client.messages
+
+
+def test_save_conversation_custom_dir(tmp_path, monkeypatch):
+    client = _client()
+    client.current_title = "CustomDir"
+    client.model_var = SimpleNamespace(get=lambda: "model-x")
+    client.messages = [{"role": "user", "content": "hi"}]
+    client.uploaded_files = []
+
+    custom = tmp_path / "mydir"
+    monkeypatch.setattr(GPT, "CONV_DIR", str(custom))
+    monkeypatch.chdir(tmp_path)
+
+    client.save_conversation(show_popup=False)
+
+    files = list(custom.glob("*.json"))
+    assert len(files) == 1


### PR DESCRIPTION
## Summary
- allow configuring conversation save location via `CONVERSATION_DIR`
- preload conversation open dialog with this directory
- test saving to a custom directory
- document new environment variable in `AGENTS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f332accf88333912b4876f9e8df2e