### PR TITLE
Add CLI support for presentation agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,9 +36,9 @@ When modifying this project, keep the following behaviors in mind:
 
 16. The command line runner accepts `--model` to override the default `OPENAI_MODEL` when creating the LLM.
 17. Automatic conversation saving runs in a background thread without showing a popup so the UI remains responsive.
-18. The Tree-of-Thoughts agent streams search steps while running but removes them from the chat once the final answer is produced so only the answer is saved.
-Document further changes to these features in this section so future Codex sessions remain aware of the expected behavior.
+18. The Tree-of-Thoughts agent streams search steps while running but removes them from the chat once the final answer is produced so only the answer is saved. Document further changes to these features in this section so future Codex sessions remain aware of the expected behavior.
 19. A simple Chain-of-Thought (CoT) agent is available. Select ``cot`` from the CLI ``--agent`` option or the GUI drop-down to run a linear reasoning loop without tool use.
+20. A presentation agent can generate HTML slides. Use ``--agent presentation`` on the CLI or choose ``プレゼンテーション`` in the GUI.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,11 @@ simple HTML slides. The assistant creates an outline in JSON and the
 application converts it to A4-sized pages with consistent styling and readable
 contrast. The resulting HTML file path is shown in the chat so you can open or
 edit it as needed.
+You can run the same feature from the command line using:
+
+```bash
+python -m src.main --agent presentation
+```
 ## Verbose Logging
 
 Set `verbose=True` when creating `ReActAgent` to enable debug output using Python's `logging` module.

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,7 @@ from openai import OpenAI
 
 from .logging_utils import setup_logging
 
-from src.agent import ReActAgent, CoTAgent, ToTAgent
+from src.agent import ReActAgent, CoTAgent, ToTAgent, PresentationAgent
 from src.tools import get_default_tools
 from src.memory import ConversationMemory
 from src.vector_memory import VectorMemory
@@ -118,7 +118,7 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--agent",
-        choices=["react", "cot", "tot"],
+        choices=["react", "cot", "tot", "presentation"],
         default="react",
         help="Which agent implementation to use (tot is experimental)",
     )
@@ -209,6 +209,8 @@ def main(argv: list[str] | None = None) -> None:
                     "Failed to load memory file %s: %s", args.memory_file, exc
                 )
         agent = CoTAgent(llm, memory, verbose=args.verbose)
+    elif args.agent == "presentation":
+        agent = PresentationAgent(llm)
     else:
         evaluator = create_evaluator(llm)
         memory = VectorMemory() if args.memory == "vector" else ConversationMemory()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -44,6 +44,11 @@ def test_parse_args_cot():
     assert args.agent == 'cot'
 
 
+def test_parse_args_presentation():
+    args = src_main.parse_args(['--agent', 'presentation'])
+    assert args.agent == 'presentation'
+
+
 def test_parse_args_tot_env(monkeypatch):
     monkeypatch.setenv('TOT_DEPTH', '7')
     monkeypatch.setenv('TOT_BREADTH', '8')
@@ -189,6 +194,27 @@ def test_main_uses_cot_agent(monkeypatch):
     monkeypatch.setattr('builtins.print', lambda *a, **k: None)
 
     src_main.main(['--agent', 'cot'])
+
+    assert called.get('called', False)
+
+
+def test_main_uses_presentation_agent(monkeypatch):
+    called = {}
+
+    class DummyPres:
+        def __init__(self, llm):
+            called['called'] = True
+
+        def run(self, q):
+            return 'ok'
+
+    monkeypatch.setattr(src_main, 'PresentationAgent', DummyPres)
+    monkeypatch.setattr(src_main, 'create_llm', lambda log_usage=True, model=None: lambda p: 'x')
+    monkeypatch.setattr(src_main, 'setup_logging', lambda **k: None)
+    monkeypatch.setattr('builtins.input', lambda prompt='': '')
+    monkeypatch.setattr('builtins.print', lambda *a, **k: None)
+
+    src_main.main(['--agent', 'presentation'])
 
     assert called.get('called', False)
 


### PR DESCRIPTION
## Summary
- add new `presentation` option to `--agent`
- invoke `PresentationAgent` when selected
- note CLI usage in documentation
- document the feature in AGENTS guidance
- test new argument and agent selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f380ff7b48333a166d5d172e30087