### PR TITLE
Document ToT environment variables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ When modifying this project, keep the following behaviors in mind:
 18. The Tree-of-Thoughts agent streams search steps while running but removes them from the chat once the final answer is produced so only the answer is saved. Document further changes to these features in this section so future Codex sessions remain aware of the expected behavior.
 19. A simple Chain-of-Thought (CoT) agent is available. Select ``cot`` from the CLI ``--agent`` option or the GUI drop-down to run a linear reasoning loop without tool use.
 20. A presentation agent can generate HTML slides. Use ``--agent presentation`` on the CLI or choose ``プレゼンテーション`` in the GUI.
+21. The Tree-of-Thoughts agent reads `TOT_DEPTH` and `TOT_BREADTH` from the environment to set its search depth and branching factor. Invalid values cause `parse_args` to exit with an error on the CLI or display an error in the GUI.
 
 ---
 


### PR DESCRIPTION
## Summary
- document TOT_DEPTH and TOT_BREADTH environment variables in AGENTS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f4bf1cab4833399080a3eb3b58546