### PR TITLE
Fix Graphviz outfile handling

### DIFF
--- a/src/tools/graphviz_tool.py
+++ b/src/tools/graphviz_tool.py
@@ -15,7 +15,8 @@ def create_graphviz_diagram(dot_code: str) -> str:
     try:
         src = Source(dot_code)
         src.format = "png"
-        src.render(out_file.name, cleanup=True)
+        # Render directly to the temporary file path
+        src.render(outfile=out_file.name, cleanup=True)
     except FileNotFoundError:
         return "Failed to generate diagram: Graphviz 'dot' executable not found"
     except subprocess.CalledProcessError as exc:

--- a/tests/test_diagram_tools.py
+++ b/tests/test_diagram_tools.py
@@ -7,9 +7,9 @@ from src.tools.mermaid_tool import create_mermaid_diagram
 
 
 def test_create_graphviz_diagram_success(monkeypatch, tmp_path):
-    def fake_render(self, filename, cleanup=True):
-        open(filename, "wb").close()
-        return filename
+    def fake_render(self, *, outfile=None, cleanup=True):
+        open(outfile, "wb").close()
+        return outfile
 
     monkeypatch.setattr(Source, "render", fake_render)
     path = create_graphviz_diagram("digraph {a->b}")
@@ -19,7 +19,7 @@ def test_create_graphviz_diagram_success(monkeypatch, tmp_path):
 
 
 def test_create_graphviz_diagram_failure(monkeypatch):
-    def fake_render(self, filename, cleanup=True):
+    def fake_render(self, *, outfile=None, cleanup=True):
         raise RuntimeError("boom")
 
     monkeypatch.setattr(Source, "render", fake_render)


### PR DESCRIPTION
## Summary
- ensure graphviz diagrams render directly to the temporary file
- adjust tests to patch `Source.render` with `outfile` keyword

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f58f8e61483338252334ca3bb8bbd