### PR TITLE
Add copy diagram feature

### DIFF
--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -285,6 +285,15 @@ class ChatGPTClient:
         )
         self.save_button.pack(pady=(0, 10))
 
+        self.copy_button = ctk.CTkButton(
+            self.diagram_panel,
+            text="コピー",
+            command=lambda: self.copy_diagram(),
+            font=(FONT_FAMILY, 14),
+            state="disabled",
+        )
+        self.copy_button.pack(pady=(0, 10))
+
         self.clear_button = ctk.CTkButton(
             self.diagram_panel,
             text="クリア",
@@ -845,6 +854,7 @@ class ChatGPTClient:
         self.diagram_label.image = preview
         self.save_button.configure(state="normal")
         self.clear_button.configure(state="normal")
+        self.copy_button.configure(state="normal")
         self._diagram_path = path
 
     def save_diagram(self) -> None:
@@ -866,7 +876,19 @@ class ChatGPTClient:
         self.diagram_label.image = None
         self.save_button.configure(state="disabled")
         self.clear_button.configure(state="disabled")
+        self.copy_button.configure(state="disabled")
         self._diagram_path = None
+
+    def copy_diagram(self) -> None:
+        """Copy the diagram path to the clipboard."""
+        if not getattr(self, "_diagram_path", None):
+            return
+        try:
+            self.window.clipboard_clear()
+            self.window.clipboard_append(self._diagram_path)
+            messagebox.showinfo("コピー完了", "図のファイルパスをコピーしました")
+        except Exception as exc:
+            messagebox.showerror("コピーエラー", str(exc))
 
     def process_queue(self):
         """キューからのメッセージをGUIに反映"""

--- a/tests/test_diagram_preview.py
+++ b/tests/test_diagram_preview.py
@@ -9,6 +9,7 @@ def _client():
     c.diagram_label = SimpleNamespace(configure=lambda **k: c.calls.setdefault('label', []).append(k), image=None)
     c.save_button = SimpleNamespace(configure=lambda **k: c.calls.setdefault('save', []).append(k))
     c.clear_button = SimpleNamespace(configure=lambda **k: c.calls.setdefault('clear', []).append(k))
+    c.copy_button = SimpleNamespace(configure=lambda **k: c.calls.setdefault('copy', []).append(k))
     c.calls = {}
     return c
 
@@ -48,4 +49,22 @@ def test_save_diagram(monkeypatch, tmp_path):
     client.save_diagram()
 
     assert dest.exists()
+    assert info_calls
+
+
+def test_copy_diagram(monkeypatch):
+    client = _client()
+    client._diagram_path = "foo.png"
+    clipboard = {}
+    client.window = SimpleNamespace(
+        clipboard_clear=lambda: clipboard.update(clear=True),
+        clipboard_append=lambda v: clipboard.update(value=v),
+    )
+    info_calls = []
+    monkeypatch.setattr(GPT.messagebox, "showinfo", lambda *a, **k: info_calls.append(a))
+    monkeypatch.setattr(GPT.messagebox, "showerror", lambda *a, **k: None)
+
+    client.copy_diagram()
+
+    assert clipboard.get("value") == "foo.png"
     assert info_calls


### PR DESCRIPTION
## Summary
- enhance diagram sidebar with a "コピー" button
- keep the button disabled until a diagram is shown
- add `copy_diagram` method for copying the PNG path to clipboard
- test new button and method

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f7890c8608333b2738ba2c85cb801