### PR TITLE
Add preferred font override via env var

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ When modifying this project, keep the following behaviors in mind:
 21. The Tree-of-Thoughts agent reads `TOT_DEPTH` and `TOT_BREADTH` from the environment to set its search depth and branching factor. Invalid values cause `parse_args` to exit with an error on the CLI or display an error in the GUI.
 
 22. The preview sidebar also includes a "コピー" button that copies the PNG file path to the clipboard so users can easily reference the generated image.
+23. ``get_font_family`` checks the ``PREFERRED_FONT`` environment variable. When set it overrides the default "Meiryo" preference before falling back to "Helvetica" if the font is unavailable.
 
 ---
 

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -32,7 +32,13 @@ from src.tools.mermaid_tool import create_mermaid_diagram
 
 
 def get_font_family(preferred: str = "Meiryo") -> str:
-    """Return preferred font if available else fall back to a standard family."""
+    """Return preferred font if available else fall back to a standard family.
+
+    The environment variable ``PREFERRED_FONT`` can override ``preferred``.
+    """
+    env_font = os.getenv("PREFERRED_FONT")
+    if env_font:
+        preferred = env_font
     try:
         root = tkinter.Tk()
         root.withdraw()

--- a/tests/test_get_font_family.py
+++ b/tests/test_get_font_family.py
@@ -1,4 +1,5 @@
 import tkinter
+from types import SimpleNamespace
 from src.ui import main as GPT
 
 
@@ -7,3 +8,24 @@ def test_get_font_family_tclerror(monkeypatch):
         raise tkinter.TclError('no display')
     monkeypatch.setattr(tkinter, 'Tk', raise_tclerror)
     assert GPT.get_font_family() == "Helvetica"
+
+
+def test_get_font_family_env(monkeypatch):
+    fonts = ["MyFont", "Helvetica"]
+
+    class DummyTk:
+        def __init__(self):
+            self.tk = SimpleNamespace(call=lambda *a: fonts)
+
+        def withdraw(self):
+            pass
+
+        def destroy(self):
+            pass
+
+    monkeypatch.setattr(tkinter, "Tk", DummyTk)
+    monkeypatch.setenv("PREFERRED_FONT", "MyFont")
+    try:
+        assert GPT.get_font_family() == "MyFont"
+    finally:
+        monkeypatch.delenv("PREFERRED_FONT", raising=False)


### PR DESCRIPTION
## Summary
- allow overriding the default GUI font by setting `PREFERRED_FONT`
- document the new environment variable
- test that the helper respects `PREFERRED_FONT`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f983e1eb083339d33059179e757b0