### PR TITLE
Implement --list-agents CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ Show the available tools and exit with `--list-tools`:
 python -m src.main --list-tools
 ```
 
+List supported agent types with `--list-agents`:
+
+```bash
+python -m src.main --list-agents
+```
+
 ## Chain-of-Thought Agent
 
 Select the simple CoT agent when you only need a single reasoning chain without tool calls:

--- a/src/main.py
+++ b/src/main.py
@@ -16,6 +16,14 @@ from src.vector_memory import VectorMemory
 
 logger = logging.getLogger(__name__)
 
+# Mapping of available agent types to brief descriptions
+AGENT_INFO = {
+    "react": "ReAct agent that uses tools",
+    "cot": "Chain-of-Thought agent",
+    "tot": "Tree-of-Thoughts agent",
+    "presentation": "Generate HTML slides",
+}
+
 
 def positive_int(value: str) -> int:
     """Return *value* as a positive ``int``.
@@ -169,6 +177,11 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
         help="List available tools and exit",
     )
     parser.add_argument(
+        "--list-agents",
+        action="store_true",
+        help="List available agent types and exit",
+    )
+    parser.add_argument(
         "--model",
         help="OpenAI model name to use (overrides OPENAI_MODEL)",
     )
@@ -196,6 +209,10 @@ def main(argv: list[str] | None = None) -> None:
     if args.list_tools:
         for t in get_default_tools():
             print(f"{t.name}: {t.description}")
+        return
+    if args.list_agents:
+        for name, desc in AGENT_INFO.items():
+            print(f"{name}: {desc}")
         return
     llm = create_llm(log_usage=True, model=args.model)
     memory = None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -28,6 +28,10 @@ def test_parse_args_list_tools():
     args = src_main.parse_args(['--list-tools'])
     assert args.list_tools
 
+def test_parse_args_list_agents():
+    args = src_main.parse_args(['--list-agents'])
+    assert args.list_agents
+
 def test_parse_args_model():
     args = src_main.parse_args(['--model', 'gpt-4'])
     assert args.model == 'gpt-4'
@@ -378,6 +382,16 @@ def test_main_list_tools(monkeypatch):
 
     assert any('web_scraper' in line for line in out)
     assert any('sqlite_query' in line for line in out)
+
+
+def test_main_list_agents(monkeypatch):
+    out = []
+    monkeypatch.setattr('builtins.print', lambda *a, **k: out.append(' '.join(map(str, a))))
+
+    src_main.main(['--list-agents'])
+
+    assert any('react' in line for line in out)
+    assert any('cot' in line for line in out)
 
 
 def test_main_passes_model(monkeypatch):


### PR DESCRIPTION
## Summary
- add `--list-agents` option in `src.main`
- document the new flag in README
- test agent listing via CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fb28d6a9883338d8166b36f764c16