### PR TITLE
Add OPENAI_BASE_URL option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ echo "OPENAI_API_KEY=your_key_here" >> .env
   The GUI also uses this value as the initial model selection and includes
   `gpt-3.5-turbo` in the drop-down menu.
 - `OPENAI_TOKEN_PRICE` – price per token for usage cost logging
-- `OPENAI_TIMEOUT` – request timeout in seconds for OpenAI API calls
-- `PREFERRED_FONT` – preferred font family for the GUI (falls back to
-  `Meiryo` or `Helvetica` if unavailable)
+  - `OPENAI_TIMEOUT` – request timeout in seconds for OpenAI API calls
+  - `OPENAI_BASE_URL` – base URL for the OpenAI API (optional)
+  - `PREFERRED_FONT` – preferred font family for the GUI (falls back to
+    `Meiryo` or `Helvetica` if unavailable)
 
 ### 4. Launch the application
 
@@ -282,7 +283,8 @@ llm = create_llm(log_usage=True)
 
 Log records will include the token count and calculated cost.
 Set `OPENAI_TIMEOUT` to adjust the request timeout in seconds for each
-OpenAI API call. Use `0` to rely on the library default.
+OpenAI API call. Use `0` to rely on the library default. Set
+`OPENAI_BASE_URL` if you need to point the client at a custom endpoint.
 
 ## Web Scraper Settings
 

--- a/src/main.py
+++ b/src/main.py
@@ -82,7 +82,11 @@ def create_llm(*, log_usage: bool = False, model: str | None = None) -> callable
     except ValueError:
         logger.warning("Invalid OPENAI_TIMEOUT=%s, using default", timeout_str)
         timeout = None
-    client = OpenAI(api_key=api_key)
+    base_url = os.getenv("OPENAI_BASE_URL")
+    client_params = {"api_key": api_key}
+    if base_url:
+        client_params["base_url"] = base_url
+    client = OpenAI(**client_params)
 
     def llm(prompt: str) -> str:
         params = {

--- a/tests/test_usage_logging.py
+++ b/tests/test_usage_logging.py
@@ -47,3 +47,26 @@ def test_create_llm_bad_timeout(monkeypatch):
     llm = src_main.create_llm()
     llm("hi")
     assert "timeout" not in dummy.last_kwargs
+
+
+def test_create_llm_base_url(monkeypatch):
+    captured = {}
+
+    class DummyClient:
+        def __init__(self):
+            self.chat = self
+            self.completions = self
+
+        def create(self, model, messages, **kwargs):
+            return DummyResp()
+
+    def fake_openai(api_key, base_url=None):
+        captured["base_url"] = base_url
+        return DummyClient()
+
+    monkeypatch.setattr(src_main, "OpenAI", fake_openai)
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://example.com")
+    llm = src_main.create_llm()
+    llm("hi")
+    assert captured["base_url"] == "https://example.com"


### PR DESCRIPTION
## Summary
- support custom OpenAI endpoints by reading `OPENAI_BASE_URL`
- document new environment variable in README
- test that `create_llm` passes `base_url`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68704722c8e88333a854f8da5e755927