### PR TITLE
Clear diagram on new chat

### DIFF
--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -826,7 +826,13 @@ class ChatGPTClient:
         self.file_list_text.configure(state="normal")
         self.file_list_text.delete("1.0", "end")
         self.file_list_text.configure(state="disabled")
-        
+
+        # 既存の図プレビューをリセット
+        try:
+            self.clear_diagram()
+        except Exception:
+            logging.warning("Failed to clear diagram", exc_info=True)
+
         self.window.title("ChatGPT Desktop")
 
     def load_chat(self):

--- a/tests/test_new_chat.py
+++ b/tests/test_new_chat.py
@@ -10,12 +10,30 @@ def _client():
     c = ChatGPTClient.__new__(ChatGPTClient)
     c.memory = ConversationMemory()
     c.memory.add("user", "hi")
-    c.chat_display = SimpleNamespace(configure=lambda *a, **k: None,
-                                     delete=lambda *a, **k: None,
-                                     insert=lambda *a, **k: None)
-    c.file_list_text = SimpleNamespace(configure=lambda *a, **k: None,
-                                       delete=lambda *a, **k: None)
+    c.chat_display = SimpleNamespace(
+        configure=lambda *a, **k: None,
+        delete=lambda *a, **k: None,
+        insert=lambda *a, **k: None,
+    )
+    c.file_list_text = SimpleNamespace(
+        configure=lambda *a, **k: None,
+        delete=lambda *a, **k: None,
+    )
     c.window = SimpleNamespace(title=lambda *a, **k: None)
+    c.calls = {}
+    c.diagram_label = SimpleNamespace(
+        configure=lambda **k: c.calls.setdefault("label", []).append(k),
+        image="img",
+    )
+    c.save_button = SimpleNamespace(
+        configure=lambda **k: c.calls.setdefault("save", []).append(k)
+    )
+    c.clear_button = SimpleNamespace(
+        configure=lambda **k: c.calls.setdefault("clear", []).append(k)
+    )
+    c.copy_button = SimpleNamespace(
+        configure=lambda **k: c.calls.setdefault("copy", []).append(k)
+    )
     return c
 
 
@@ -24,3 +42,14 @@ def test_new_chat_clears_memory():
     assert client.memory.messages
     client.new_chat()
     assert client.memory.messages == []
+
+
+def test_new_chat_resets_diagram_preview():
+    client = _client()
+    client._diagram_path = "dummy.png"
+    client.new_chat()
+    assert client._diagram_path is None
+    assert client.diagram_label.image is None
+    assert any(k.get("state") == "disabled" for k in client.calls.get("save", []))
+    assert any(k.get("state") == "disabled" for k in client.calls.get("clear", []))
+    assert any(k.get("state") == "disabled" for k in client.calls.get("copy", []))


### PR DESCRIPTION
## Summary
- reset diagram preview when starting a new conversation
- disable sidebar buttons in new chat
- test that diagram preview and buttons reset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870960e4a4c8333a84ad774e34c6bde