### PR TITLE
Fix font fallback logic

### DIFF
--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -40,11 +40,10 @@ def get_font_family(preferred: str = "Meiryo") -> str:
     falling back to the ``preferred`` parameter and finally ``Helvetica``.
     """
     env_font = os.getenv("PREFERRED_FONT")
-    candidates = [preferred]
+    candidates = []
     if env_font:
-        candidates = [f.strip() for f in env_font.split(",") if f.strip()]
-    else:
-        candidates = [preferred]
+        candidates.extend([f.strip() for f in env_font.split(",") if f.strip()])
+    candidates.append(preferred)
     try:
         root = tkinter.Tk()
         root.withdraw()

--- a/tests/test_get_font_family.py
+++ b/tests/test_get_font_family.py
@@ -50,3 +50,24 @@ def test_get_font_family_env_missing(monkeypatch):
         assert GPT.get_font_family() == "Helvetica"
     finally:
         monkeypatch.delenv("PREFERRED_FONT", raising=False)
+
+
+def test_get_font_family_env_fallback(monkeypatch):
+    fonts = ["Meiryo", "Helvetica"]
+
+    class DummyTk:
+        def __init__(self):
+            self.tk = SimpleNamespace(call=lambda *a: fonts)
+
+        def withdraw(self):
+            pass
+
+        def destroy(self):
+            pass
+
+    monkeypatch.setattr(tkinter, "Tk", DummyTk)
+    monkeypatch.setenv("PREFERRED_FONT", "Missing1, Missing2")
+    try:
+        assert GPT.get_font_family() == "Meiryo"
+    finally:
+        monkeypatch.delenv("PREFERRED_FONT", raising=False)


### PR DESCRIPTION
## Summary
- append default font after env preference list so we try it if env fonts are missing
- cover fallback branch with new unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6870ad9fce408333b917cda4fd2c3e1b