### PR TITLE
Fix window title updates from background threads

### DIFF
--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -63,6 +63,7 @@ def test_get_response_stream(monkeypatch):
 def test_generate_title_logs_error(caplog):
     client = ChatGPTClient.__new__(ChatGPTClient)
     client.window = SimpleNamespace(title=lambda *a, **k: None)
+    client.response_queue = queue.Queue()
 
     def raise_err(*a, **k):
         raise RuntimeError("boom")
@@ -76,6 +77,7 @@ def test_generate_title_logs_error(caplog):
 
     assert "boom" in caplog.text
     assert client.current_title
+    assert client.response_queue.get().startswith("__TITLE__")
 
 
 def test_get_response_tool_calls(monkeypatch):


### PR DESCRIPTION
## Summary
- ensure `generate_title` enqueues a title update instead of calling `window.title` directly
- handle `__TITLE__` messages in `process_queue`
- adjust streaming test for new queue behavior
- stream tokens for CoT, ReAct, and ToT agents

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871bd5d10ec8333b3ee2577e82d0f7d