### PR TITLE
Sync ToT level menu with constants

### DIFF
--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -255,7 +255,7 @@ class ChatGPTClient:
 
         tot_menu = ctk.CTkOptionMenu(
             left_panel,
-            values=["LOW", "MIDDLE", "HIGH"],
+            values=list(TOT_LEVELS.keys()),
             variable=self.tot_level_var,
             width=250,
         )


### PR DESCRIPTION
## Summary
- extend ToT level dropdown to list all presets
- derive dropdown values from `constants.TOT_LEVELS` so new presets appear automatically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871cad027188333bd64146de1d98e36