### PR TITLE
Improve model options and base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ echo "OPENAI_API_KEY=your_key_here" >> .env
 
 - `OPENAI_MODEL` – default model to use (defaults to `gpt-3.5-turbo`).
   The GUI also uses this value as the initial model selection and includes
-  `gpt-3.5-turbo` in the drop-down menu.
+  `gpt-3.5-turbo` and `gpt-4o` in the drop-down menu.
 - `OPENAI_TOKEN_PRICE` – price per token for usage cost logging
   - `OPENAI_TIMEOUT` – request timeout in seconds for OpenAI API calls
-  - `OPENAI_BASE_URL` – base URL for the OpenAI API (optional)
+  - `OPENAI_BASE_URL` – base URL for the OpenAI API (optional, also respected by the GUI)
   - `PREFERRED_FONT` – preferred font family or comma-separated list of
     candidates for the GUI (falls back to `Meiryo` or `Helvetica` if none are
     available)

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -18,7 +18,7 @@
    cp .env.example .env
    echo "OPENAI_API_KEY=your_key_here" >> .env
    ```
-  必要に応じて `OPENAI_MODEL` や `OPENAI_TIMEOUT`、`PREFERRED_FONT` などの環境変数も指定できます。`PREFERRED_FONT` はカンマ区切りで複数の候補を指定できます。
+  必要に応じて `OPENAI_MODEL` や `OPENAI_TIMEOUT`、`OPENAI_BASE_URL`、`PREFERRED_FONT` などの環境変数も指定できます。`PREFERRED_FONT` はカンマ区切りで複数の候補を指定できます。
 
 ## 2. アプリケーションの起動
 

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -114,8 +114,12 @@ class ChatGPTClient:
             return
 
         logging.info("Loaded OpenAI API key from environment")
-        
-        self.client = OpenAI(api_key=api_key)
+
+        base_url = os.getenv("OPENAI_BASE_URL")
+        if base_url:
+            self.client = OpenAI(api_key=api_key, base_url=base_url)
+        else:
+            self.client = OpenAI(api_key=api_key)
 
         timeout_str = os.getenv("OPENAI_TIMEOUT", "0")
         try:
@@ -218,6 +222,7 @@ class ChatGPTClient:
             left_panel,
             values=[
                 "gpt-3.5-turbo",
+                "gpt-4o",
                 "gpt-4.1-mini-2025-04-14",
                 "gpt-4.1-nano-2025-04-14",
                 "gpt-4.1-2025-04-14",


### PR DESCRIPTION
## Summary
- add support for `OPENAI_BASE_URL` when creating the GUI client
- include `gpt-4o` in the model selection menu
- document new model option and base URL usage in README and Japanese guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871e052b7b883338b00424089291705