### PR TITLE
Add case-insensitive search for ConversationMemory

### DIFF
--- a/src/memory.py
+++ b/src/memory.py
@@ -60,5 +60,10 @@ class ConversationMemory(MessageMemory):
 
     def search(self, query: str, top_k: int = 3) -> List[str]:
         """Return messages containing the query text."""
-        results = [m["content"] for m in self.messages if query in m["content"]]
+        query_lower = query.lower()
+        results = [
+            m["content"]
+            for m in self.messages
+            if query_lower in m["content"].lower()
+        ]
         return results[:top_k]

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -27,3 +27,11 @@ def test_save_filename_no_directory(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     mem.save("conv.json")
     assert (tmp_path / "conv.json").exists()
+
+
+def test_search_case_insensitive():
+    mem = ConversationMemory()
+    mem.add("user", "Hello World")
+    mem.add("assistant", "How are you?")
+    results = mem.search("hello")
+    assert "Hello World" in results


### PR DESCRIPTION
## Summary
- make `ConversationMemory.search` case-insensitive
- add regression test for mixed-case queries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d595fe4c83339fb416d3dc3f2f6d