### PR TITLE
Change default model to gpt-4.1-mini

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 OPENAI_API_KEY=
 
 # Optional default model used by create_llm
-# OPENAI_MODEL=gpt-3.5-turbo
+# OPENAI_MODEL=gpt-4.1-mini-2025-04-14
 
 # Optional token price per token for usage cost logging
 # OPENAI_TOKEN_PRICE=0.000002

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ echo "OPENAI_API_KEY=your_key_here" >> .env
 
 -`create_llm` reads additional variables if present:
 
-- `OPENAI_MODEL` – default model to use (defaults to `gpt-3.5-turbo`).
+- `OPENAI_MODEL` – default model to use (defaults to `gpt-4.1-mini-2025-04-14`).
   The GUI also uses this value as the initial model selection and includes
+  `gpt-4.1-mini-2025-04-14`, `gpt-4.1-nano-2025-04-14`, `gpt-4.1-2025-04-14`,
   `gpt-3.5-turbo` and `gpt-4o` in the drop-down menu.
 - `OPENAI_TOKEN_PRICE` – price per token for usage cost logging
   - `OPENAI_TIMEOUT` – request timeout in seconds for OpenAI API calls
@@ -286,7 +287,7 @@ The `create_llm` helper can log the number of tokens consumed and estimate the
 cost of each OpenAI API call. Set `OPENAI_TOKEN_PRICE` in your environment to the
 price per token (e.g. `0.000002`) and pass `log_usage=True` when creating the
 LLM. The cost is calculated as `token_count * OPENAI_TOKEN_PRICE`. The model used
-for completion defaults to `gpt-3.5-turbo` but can be overridden with
+for completion defaults to `gpt-4.1-mini-2025-04-14` but can be overridden with
 `OPENAI_MODEL`:
 
 ```python

--- a/src/main.py
+++ b/src/main.py
@@ -85,7 +85,7 @@ def create_llm(*, log_usage: bool = False, model: str | None = None) -> callable
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY not set")
-    model = model or os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+    model = model or os.getenv("OPENAI_MODEL", "gpt-4.1-mini-2025-04-14")
     token_price = float(os.getenv("OPENAI_TOKEN_PRICE", "0"))
     timeout_str = os.getenv("OPENAI_TIMEOUT", "0")
     try:

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -102,7 +102,7 @@ class ChatGPTClient:
             logging.warning("Failed to set window icon")
 
         # モデルの初期値を環境変数から読み込む
-        default_model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+        default_model = os.getenv("OPENAI_MODEL", "gpt-4.1-mini-2025-04-14")
         self.model_var = ctk.StringVar(value=default_model)
         
         # OpenAI クライアントの初期化


### PR DESCRIPTION
## Summary
- default to `gpt-4.1-mini-2025-04-14`
- update docs for new model name

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68725d6cee008333ac86ba4e8a786ba6