### PR TITLE
Fix logging for streaming error

### DIFF
--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -694,6 +694,7 @@ class ChatGPTClient:
                 break
 
         except Exception as e:
+            logging.exception("Streaming failed: %s", e)
             self.response_queue.put(f"\n\nエラー: {str(e)}\n")
 
     def simple_llm(self, prompt: str, *, stream: bool = False, prefix: str = "") -> str:


### PR DESCRIPTION
## Summary
- log streaming errors in `ChatGPTClient.get_response`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687262d4d5a48333baef86df2a711a24