### PR TITLE
Scale window size to screen

### DIFF
--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -93,7 +93,12 @@ class ChatGPTClient:
         """Initialize the main window and OpenAI client."""
         self.window = ctk.CTk()
         self.window.title("ChatGPT Desktop")
-        self.window.geometry("1200x800")
+
+        screen_width = self.window.winfo_screenwidth()
+        screen_height = self.window.winfo_screenheight()
+        init_width = min(int(screen_width * 0.9), 1200)
+        init_height = min(int(screen_height * 0.9), 800)
+        self.window.geometry(f"{init_width}x{init_height}")
         # Allow shrinking on smaller displays
         self.window.minsize(800, 600)
         try:


### PR DESCRIPTION
## Summary
- use `winfo_screenwidth` and `winfo_screenheight` to size the main window
- cap width to 1200 and height to 800 while preserving minimum 800x600

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68745bd42bbc8333a5803aa4fc531677